### PR TITLE
feat(workspace): add Agent-level workspace artifacts catalog (#514)

### DIFF
--- a/mateclaw-server/src/main/java/vip/mate/agent/context/ChatOrigin.java
+++ b/mateclaw-server/src/main/java/vip/mate/agent/context/ChatOrigin.java
@@ -81,6 +81,21 @@ public record ChatOrigin(
     /** Key used when this origin is wrapped into a Spring AI {@link ToolContext}. */
     public static final String CTX_KEY = "mateclaw.chatOrigin";
 
+    /**
+     * Context-map key carrying the current tool-call id (issue #514). Populated
+     * by {@code ToolExecutionExecutor.executeSingleTool} so document-render tools
+     * can stamp their output with provenance. Read via {@link #toolCallId(org.springframework.ai.chat.model.ToolContext)}.
+     * Not a record field — kept as a loose context key to avoid the record's
+     * add-only / 90-day-deprecation evolution rule.
+     */
+    public static final String TOOL_CALL_ID_KEY = "mateclaw.toolCallId";
+
+    /**
+     * Context-map key carrying the current tool's bean/display name (issue #514),
+     * so artifacts can record which tool produced them.
+     */
+    public static final String TOOL_NAME_KEY = "mateclaw.toolName";
+
     /** Sentinel used by AgentService default overloads where no origin is supplied. */
     public static final ChatOrigin EMPTY =
             new ChatOrigin(null, null, "", null, null, null, null, false, null, null, null, null, null);
@@ -188,5 +203,27 @@ public record ChatOrigin(
         if (ctx == null) return EMPTY;
         Object v = ctx.getContext().get(CTX_KEY);
         return v instanceof ChatOrigin co ? co : EMPTY;
+    }
+
+    /**
+     * Read the tool-call id stamped into the context by the executor (issue #514).
+     * Returns {@code null} when no tool-call id is present (e.g. a tool invoked
+     * outside the agent graph, or a unit test).
+     */
+    @Nullable
+    public static String toolCallId(@Nullable ToolContext ctx) {
+        if (ctx == null) return null;
+        Object v = ctx.getContext().get(TOOL_CALL_ID_KEY);
+        return v instanceof String s && !s.isBlank() ? s : null;
+    }
+
+    /**
+     * Read the tool name stamped into the context by the executor (issue #514).
+     */
+    @Nullable
+    public static String toolName(@Nullable ToolContext ctx) {
+        if (ctx == null) return null;
+        Object v = ctx.getContext().get(TOOL_NAME_KEY);
+        return v instanceof String s && !s.isBlank() ? s : null;
     }
 }

--- a/mateclaw-server/src/main/java/vip/mate/agent/graph/executor/ToolExecutionExecutor.java
+++ b/mateclaw-server/src/main/java/vip/mate/agent/graph/executor/ToolExecutionExecutor.java
@@ -900,13 +900,22 @@ public class ToolExecutionExecutor {
                         .withWorkspace(runtimeOrigin.workspaceId(), pc.workspaceBasePath);
                 ToolContext toolContext = runtimeOrigin.toToolContext();
 
+                // Issue #514: thread the tool-call id into the context map so
+                // document-render tools can register the artifacts they produce
+                // with provenance. Mirrors the MCP-progress injection below — a
+                // plain map key, no ChatOrigin record change (the record has a
+                // strict "add-only, 90-day deprecation" evolution rule).
+                Map<String, Object> ctxMap = new HashMap<>(toolContext.getContext());
+                ctxMap.put(ChatOrigin.TOOL_CALL_ID_KEY, pc.toolCall.id());
+                ctxMap.put(ChatOrigin.TOOL_NAME_KEY, toolName);
+                toolContext = new ToolContext(ctxMap);
+
                 // MCP progress: generate progressToken and inject into ToolContext
                 // so ProgressAwareMcpToolCallback can include it in tools/call _meta.
                 if (progressContext != null) {
                     progressToken = UUID.randomUUID().toString();
                     progressContext.register(progressToken,
                             new McpProgressContext.ProgressEntry(pc.conversationId, pc.toolCall.id(), toolName));
-                    Map<String, Object> ctxMap = new HashMap<>(toolContext.getContext());
                     ctxMap.put(ProgressAwareMcpToolCallback.MCP_PROGRESS_TOKEN_KEY, progressToken);
                     toolContext = new ToolContext(ctxMap);
                 }

--- a/mateclaw-server/src/main/java/vip/mate/channel/webchat/WebChatController.java
+++ b/mateclaw-server/src/main/java/vip/mate/channel/webchat/WebChatController.java
@@ -1608,7 +1608,13 @@ public class WebChatController {
         if (agentId == null) {
             return R.fail(400, "No agent configured for this WebChat channel");
         }
-        Long workspaceId = channel.getWorkspaceId() != null ? channel.getWorkspaceId() : 1L;
+        // Use the AGENT's workspaceId, not the channel's — agent-produced
+        // artifacts are registered under the agent's workspace (chatStream
+        // builds the ChatOrigin from webAgent.getWorkspaceId()), so the list
+        // filter must read the same source to stay consistent.
+        vip.mate.agent.model.AgentEntity listAgent = agentService.getAgent(agentId);
+        Long workspaceId = listAgent != null && listAgent.getWorkspaceId() != null
+                ? listAgent.getWorkspaceId() : 1L;
         // sessionId filter uses the server-derived conversationId (same key the
         // upload/agent paths store), so the listing filter matches the
         // registration key exactly.
@@ -1753,7 +1759,10 @@ public class WebChatController {
             entity.setChannelId(channel.getId());
             entity.setAgentId(channel.getAgentId());
             entity.setConversationId(conversationId);
-            entity.setSessionLabel(sessionLabel);
+            // Store conversationId (not the raw sessionLabel) so user uploads
+            // and agent artifacts share the same sessionId format in the VO —
+            // both use the server-derived conversationId as the provenance key.
+            entity.setSessionLabel(conversationId);
             entity.setToolCallId(null);
             entity.setToolName(null);
             entity.setSource(WorkspaceArtifactService.SOURCE_USER);

--- a/mateclaw-server/src/main/java/vip/mate/channel/webchat/WebChatController.java
+++ b/mateclaw-server/src/main/java/vip/mate/channel/webchat/WebChatController.java
@@ -1649,6 +1649,9 @@ public class WebChatController {
         if (!verifyVisitorToken(visitorTokenSecret, channel.getId(), visitorId, visitorToken)) {
             return ResponseEntity.status(401).build();
         }
+        if (channel.getAgentId() == null) {
+            return ResponseEntity.status(400).build();
+        }
         Long artifactId;
         try {
             artifactId = Long.parseLong(id);

--- a/mateclaw-server/src/main/java/vip/mate/channel/webchat/WebChatController.java
+++ b/mateclaw-server/src/main/java/vip/mate/channel/webchat/WebChatController.java
@@ -51,6 +51,9 @@ import reactor.core.Disposable;
 import vip.mate.approval.PendingApproval;
 import vip.mate.approval.ResolveOutcome;
 import vip.mate.agent.context.ChatOrigin;
+import vip.mate.workspace.artifact.model.WorkspaceArtifactEntity;
+import vip.mate.workspace.artifact.service.WorkspaceArtifactService;
+import vip.mate.workspace.artifact.vo.ArtifactPageVO;
 
 /**
  * WebChat 嵌入式对话接口
@@ -91,6 +94,12 @@ public class WebChatController {
      * and the turn was wasted.
      */
     private final vip.mate.approval.ApprovalWorkflowService approvalService;
+
+    /**
+     * Issue #514: registers user-uploaded + agent-produced files into the
+     * Agent's workspace artifact catalog and serves the cross-session listing.
+     */
+    private final WorkspaceArtifactService artifactService;
 
     /** Visitor-token TTL in seconds (7 days). Mirrors GeneratedFileCache's TTL. */
     static final long VISITOR_TOKEN_TTL_SECONDS = 7 * 24 * 3600L;
@@ -1489,6 +1498,10 @@ public class WebChatController {
             audit(channel, vid, "webchat.upload-file", conversationId,
                     "{\"sessionId\":\"" + sid + "\",\"fileId\":\"" + stored.storedName()
                             + "\",\"size\":" + stored.size() + "}");
+            // Issue #514: register the user upload into the workspace artifact
+            // catalog so it shows up in the cross-session file listing. Best-effort
+            // — a catalog write failure must not fail the upload (the file is stored).
+            registerUserUpload(channel, conversationId, sid, stored);
             return R.ok(Map.of(
                     "fileId", stored.storedName(),
                     "fileName", stored.originalName(),
@@ -1562,6 +1575,92 @@ public class WebChatController {
                 .header(HttpHeaders.CONTENT_DISPOSITION,
                         (inlineImage ? "inline" : "attachment") + "; filename*=UTF-8''" + encodedName)
                 .body(new FileSystemResource(file));
+    }
+
+    // ==================== Issue #514: Workspace Artifacts ====================
+
+    /**
+     * List the Agent workspace's full file inventory — both Agent-produced
+     * output and user uploads — across all sessions (issue #514). Files live
+     * at the Agent/Workspace level; sessions are a provenance filter only.
+     */
+    @Operation(summary = "列出 Agent 工作空间的产出文件")
+    @GetMapping("/artifacts")
+    public R<ArtifactPageVO> listArtifacts(
+            @RequestHeader("X-MC-Key") String apiKey,
+            @RequestHeader(value = "X-MC-Visitor-Token", required = false) String visitorToken,
+            @RequestParam String visitorId,
+            @RequestParam(required = false) String sessionId,
+            @RequestParam(required = false) String source,
+            @RequestParam(required = false) String type,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "50") int size) {
+        ChannelEntity channel = resolveChannel(apiKey);
+        if (channel == null) {
+            return R.fail(401, "Invalid API Key");
+        }
+        if (!verifyVisitorToken(visitorTokenSecret, channel.getId(), visitorId, visitorToken)) {
+            return R.fail(401, "Invalid or missing visitor token");
+        }
+        Long agentId = channel.getAgentId();
+        if (agentId == null) {
+            return R.fail(400, "No agent configured for this WebChat channel");
+        }
+        Long workspaceId = channel.getWorkspaceId() != null ? channel.getWorkspaceId() : 1L;
+        // sessionId filter uses the server-derived conversationId (same key the
+        // upload/agent paths store), so the listing filter matches the
+        // registration key exactly.
+        String conversationId = null;
+        if (sessionId != null && !sessionId.isBlank()) {
+            try {
+                conversationId = deriveConversationId(apiKey,
+                        normalizeVisitorId(visitorId), normalizeSessionId(sessionId));
+            } catch (IllegalArgumentException ex) {
+                return R.fail(400, ex.getMessage());
+            }
+        }
+        ArtifactPageVO result = artifactService.list(agentId, workspaceId,
+                conversationId, source, type, page, size);
+        audit(channel, visitorId, "webchat.list-artifacts", null,
+                "{\"agentId\":" + agentId + ",\"page\":" + page + ",\"size\":" + size + "}");
+        return R.ok(result);
+    }
+
+    /**
+     * Register a user-uploaded file into the workspace artifact catalog
+     * (issue #514, source=user). Best-effort: swallows exceptions so a
+     * catalog write failure never fails the upload.
+     */
+    private void registerUserUpload(ChannelEntity channel, String conversationId,
+                                    String sessionLabel,
+                                    WebChatFileService.StagedFile stored) {
+        try {
+            WorkspaceArtifactEntity entity = new WorkspaceArtifactEntity();
+            entity.setWorkspaceId(channel.getWorkspaceId() != null ? channel.getWorkspaceId() : 1L);
+            entity.setChannelId(channel.getId());
+            entity.setAgentId(channel.getAgentId());
+            entity.setConversationId(conversationId);
+            entity.setSessionLabel(sessionLabel);
+            entity.setToolCallId(null);
+            entity.setToolName(null);
+            entity.setSource(WorkspaceArtifactService.SOURCE_USER);
+            entity.setArtifactType(WorkspaceArtifactService.classifyType(
+                    stored.originalName(), stored.contentType()));
+            entity.setName(stored.originalName());
+            entity.setMime(stored.contentType());
+            entity.setSizeBytes(stored.size());
+            entity.setStorageKind(WorkspaceArtifactService.STORAGE_UPLOAD);
+            entity.setStorageRef(stored.storedName());
+            // User uploads are served by the existing session-scoped /files
+            // endpoint; the download URL carries the session so the endpoint
+            // can re-derive the storage path.
+            entity.setDownloadUrl("/api/v1/channels/webchat/files?storedName="
+                    + stored.storedName());
+            artifactService.register(entity);
+        } catch (Exception e) {
+            log.warn("[WebChat] artifact registration failed for upload {}: {}",
+                    stored.storedName(), e.toString());
+        }
     }
 
     /**

--- a/mateclaw-server/src/main/java/vip/mate/channel/webchat/WebChatController.java
+++ b/mateclaw-server/src/main/java/vip/mate/channel/webchat/WebChatController.java
@@ -54,6 +54,7 @@ import vip.mate.agent.context.ChatOrigin;
 import vip.mate.workspace.artifact.model.WorkspaceArtifactEntity;
 import vip.mate.workspace.artifact.service.WorkspaceArtifactService;
 import vip.mate.workspace.artifact.vo.ArtifactPageVO;
+import vip.mate.tool.document.GeneratedFileCache;
 
 /**
  * WebChat 嵌入式对话接口
@@ -100,6 +101,7 @@ public class WebChatController {
      * Agent's workspace artifact catalog and serves the cross-session listing.
      */
     private final WorkspaceArtifactService artifactService;
+    private final GeneratedFileCache generatedFileCache;
 
     /** Visitor-token TTL in seconds (7 days). Mirrors GeneratedFileCache's TTL. */
     static final long VISITOR_TOKEN_TTL_SECONDS = 7 * 24 * 3600L;
@@ -1627,6 +1629,114 @@ public class WebChatController {
     }
 
     /**
+     * Download a workspace artifact by its catalog id (issue #514). Resolves
+     * the backing store from the artifact row — works for both agent-produced
+     * files ({@code generated_cache}) and user uploads ({@code upload}) without
+     * the caller re-deriving the conversationId. Auth: X-MC-Key + visitor token,
+     * same as the list endpoint.
+     */
+    @Operation(summary = "下载工作空间产出文件")
+    @GetMapping("/artifacts/{id}/download")
+    public ResponseEntity<Resource> downloadArtifact(
+            @RequestHeader("X-MC-Key") String apiKey,
+            @RequestHeader(value = "X-MC-Visitor-Token", required = false) String visitorToken,
+            @RequestParam String visitorId,
+            @PathVariable String id) {
+        ChannelEntity channel = resolveChannel(apiKey);
+        if (channel == null) {
+            return ResponseEntity.status(401).build();
+        }
+        if (!verifyVisitorToken(visitorTokenSecret, channel.getId(), visitorId, visitorToken)) {
+            return ResponseEntity.status(401).build();
+        }
+        Long artifactId;
+        try {
+            artifactId = Long.parseLong(id);
+        } catch (NumberFormatException ex) {
+            return ResponseEntity.badRequest().build();
+        }
+        WorkspaceArtifactEntity artifact = artifactService.findById(artifactId);
+        if (artifact == null
+                || !Integer.valueOf(0).equals(artifact.getDeleted())
+                || !channel.getAgentId().equals(artifact.getAgentId())) {
+            return ResponseEntity.notFound().build();
+        }
+        Path file;
+        long size;
+        String mime;
+        String name;
+        try {
+            if (WorkspaceArtifactService.STORAGE_GENERATED_CACHE.equals(artifact.getStorageKind())) {
+                GeneratedFileCache.Entry entry = generatedFileCache
+                        .get(artifact.getStorageRef()).orElse(null);
+                if (entry == null) {
+                    return ResponseEntity.notFound().build();
+                }
+                // Serve the cached bytes directly.
+                name = entry.filename();
+                mime = entry.mimeType();
+                size = entry.bytes() != null ? entry.bytes().length : 0;
+                String encodedName = URLEncoder.encode(name, StandardCharsets.UTF_8).replace("+", "%20");
+                MediaType mediaType = mime != null
+                        ? safeParseMediaType(mime) : MediaType.APPLICATION_OCTET_STREAM;
+                boolean inlineImage = mime != null && mime.startsWith("image/");
+                return ResponseEntity.ok()
+                        .contentType(mediaType)
+                        .header("X-Content-Type-Options", "nosniff")
+                        .header(HttpHeaders.CONTENT_DISPOSITION,
+                                (inlineImage ? "inline" : "attachment")
+                                        + "; filename*=UTF-8''" + encodedName)
+                        .header(HttpHeaders.CONTENT_LENGTH, String.valueOf(size))
+                        .body(new org.springframework.core.io.ByteArrayResource(entry.bytes()));
+            }
+            // User upload: resolve from the conversation dir.
+            file = fileService.resolve(artifact.getConversationId(),
+                    artifact.getStorageRef()).orElse(null);
+            if (file == null) {
+                return ResponseEntity.notFound().build();
+            }
+            name = artifact.getName();
+            mime = artifact.getMime();
+            try {
+                size = java.nio.file.Files.size(file);
+            } catch (IOException ignore) {
+                size = 0;
+            }
+        } catch (Exception e) {
+            log.warn("[WebChat] artifact download failed id={}: {}", id, e.toString());
+            return ResponseEntity.status(500).build();
+        }
+        String contentType = null;
+        try {
+            contentType = java.nio.file.Files.probeContentType(file);
+        } catch (IOException e) {
+            // fall back to artifact mime
+        }
+        if (contentType == null) {
+            contentType = mime != null ? mime : "application/octet-stream";
+        }
+        MediaType mediaType = safeParseMediaType(contentType);
+        boolean inlineImage = contentType.startsWith("image/");
+        String encodedName = URLEncoder.encode(name, StandardCharsets.UTF_8).replace("+", "%20");
+        return ResponseEntity.ok()
+                .contentType(mediaType)
+                .header("X-Content-Type-Options", "nosniff")
+                .header(HttpHeaders.CONTENT_DISPOSITION,
+                        (inlineImage ? "inline" : "attachment")
+                                + "; filename*=UTF-8''" + encodedName)
+                .header(HttpHeaders.CONTENT_LENGTH, String.valueOf(size))
+                .body(new FileSystemResource(file));
+    }
+
+    private MediaType safeParseMediaType(String mime) {
+        try {
+            return MediaType.parseMediaType(mime);
+        } catch (Exception e) {
+            return MediaType.APPLICATION_OCTET_STREAM;
+        }
+    }
+
+    /**
      * Register a user-uploaded file into the workspace artifact catalog
      * (issue #514, source=user). Best-effort: swallows exceptions so a
      * catalog write failure never fails the upload.
@@ -1651,11 +1761,9 @@ public class WebChatController {
             entity.setSizeBytes(stored.size());
             entity.setStorageKind(WorkspaceArtifactService.STORAGE_UPLOAD);
             entity.setStorageRef(stored.storedName());
-            // User uploads are served by the existing session-scoped /files
-            // endpoint; the download URL carries the session so the endpoint
-            // can re-derive the storage path.
-            entity.setDownloadUrl("/api/v1/channels/webchat/files?storedName="
-                    + stored.storedName());
+            // downloadUrl is built at read-time in WorkspaceArtifactService.toVO()
+            // from the artifact id, so it does not need to be set here.
+            entity.setDownloadUrl(null);
             artifactService.register(entity);
         } catch (Exception e) {
             log.warn("[WebChat] artifact registration failed for upload {}: {}",

--- a/mateclaw-server/src/main/java/vip/mate/tool/builtin/CodeExecuteTool.java
+++ b/mateclaw-server/src/main/java/vip/mate/tool/builtin/CodeExecuteTool.java
@@ -22,6 +22,7 @@ import vip.mate.skill.secret.SkillSecretService;
 import vip.mate.tool.document.GeneratedFileCache;
 import vip.mate.tool.document.WorkspaceArtifactSurfacer;
 import vip.mate.tool.guard.WorkspacePathGuard;
+import vip.mate.workspace.artifact.service.WorkspaceArtifactService;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -61,6 +62,7 @@ public class CodeExecuteTool {
     private final SkillSecretService skillSecretService;
     private final ObjectMapper objectMapper;
     private final GeneratedFileCache generatedFileCache;
+    private final WorkspaceArtifactService artifactService;
 
     @Lazy
     @Autowired
@@ -161,7 +163,7 @@ public class CodeExecuteTool {
             // Surface any files the run wrote as one-click downloads so the user can
             // grab generated artifacts (xlsx / csv / images / …) without the model
             // having to call send_file or echo a server path.
-            List<String> fileLinks = WorkspaceArtifactSurfacer.collect(generatedFileCache, workingDir, runStart, ctx);
+            List<String> fileLinks = WorkspaceArtifactSurfacer.collect(generatedFileCache, workingDir, runStart, ctx, artifactService);
             return formatResult(result, fileLinks);
         } catch (Exception e) {
             log.error("[CodeExecute] Execution failed: {}", e.getMessage());

--- a/mateclaw-server/src/main/java/vip/mate/tool/builtin/DocxRenderTool.java
+++ b/mateclaw-server/src/main/java/vip/mate/tool/builtin/DocxRenderTool.java
@@ -14,6 +14,7 @@ import vip.mate.tool.document.MarkdownDocxRenderer;
 import vip.mate.tool.document.MarkdownInputResolver;
 import vip.mate.tool.document.MarkdownInputResolver.Resolved;
 import vip.mate.tool.document.MarkdownInputResolver.ResolveException;
+import vip.mate.workspace.artifact.service.WorkspaceArtifactService;
 
 import java.util.List;
 
@@ -39,6 +40,7 @@ public class DocxRenderTool {
 
     private final MarkdownDocxRenderer renderer;
     private final GeneratedFileCache cache;
+    private final WorkspaceArtifactService artifactService;
 
     @Tool(description = """
         Render a new .docx (Microsoft Word) file from Markdown text and return a
@@ -87,7 +89,7 @@ public class DocxRenderTool {
             byte[] bytes = renderer.render(markdown, size);
             log.info("[DocxRender] generated {} ({} bytes, {}ms)",
                     displayName, bytes.length, System.currentTimeMillis() - t0);
-            return GeneratedFileLink.resultZh(bytes, displayName, DOCX_MIME, cache, "文档", ctx);
+            return GeneratedFileLink.resultZh(bytes, displayName, DOCX_MIME, cache, "文档", ctx, artifactService);
         } catch (Exception e) {
             log.error("[DocxRender] render failed for {}: {}", displayName, e.getMessage(), e);
             return "渲染失败：" + e.getMessage();
@@ -153,7 +155,7 @@ public class DocxRenderTool {
             byte[] bytes = renderer.render(input.markdown(), size);
             log.info("[DocxRender] generated {} ({} bytes from {} bytes md, {}ms)",
                     displayName, bytes.length, input.totalBytes(), System.currentTimeMillis() - t0);
-            return GeneratedFileLink.resultEn(bytes, displayName, DOCX_MIME, cache, "Document", 1, ctx);
+            return GeneratedFileLink.resultEn(bytes, displayName, DOCX_MIME, cache, "Document", 1, ctx, artifactService);
         } catch (Exception e) {
             log.error("[DocxRender] render failed for {} (source: {}): {}",
                     displayName, input.sources().get(0), e.getMessage(), e);
@@ -215,7 +217,7 @@ public class DocxRenderTool {
                     displayName, bytes.length, input.fileCount(), input.totalBytes(),
                     System.currentTimeMillis() - t0);
             return GeneratedFileLink.resultEn(bytes, displayName, DOCX_MIME, cache,
-                    "Document", input.fileCount(), ctx);
+                    "Document", input.fileCount(), ctx, artifactService);
         } catch (Exception e) {
             log.error("[DocxRender] render failed for {} (sources: {}): {}",
                     displayName, input.sources(), e.getMessage(), e);

--- a/mateclaw-server/src/main/java/vip/mate/tool/builtin/HtmlImageRenderTool.java
+++ b/mateclaw-server/src/main/java/vip/mate/tool/builtin/HtmlImageRenderTool.java
@@ -18,6 +18,7 @@ import vip.mate.tool.document.FilenameSanitizer;
 import vip.mate.tool.document.GeneratedFileCache;
 import vip.mate.tool.document.GeneratedFileLink;
 import vip.mate.tool.guard.WorkspacePathGuard;
+import vip.mate.workspace.artifact.service.WorkspaceArtifactService;
 
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -44,12 +45,14 @@ public class HtmlImageRenderTool {
     private static final int SET_CONTENT_TIMEOUT_MS = 15_000;
 
     private final GeneratedFileCache cache;
+    private final WorkspaceArtifactService artifactService;
 
     private volatile Playwright sharedPlaywright;
     private final Object playwrightLock = new Object();
 
-    public HtmlImageRenderTool(GeneratedFileCache cache) {
+    public HtmlImageRenderTool(GeneratedFileCache cache, WorkspaceArtifactService artifactService) {
         this.cache = cache;
+        this.artifactService = artifactService;
     }
 
     @Tool(description = """
@@ -120,7 +123,7 @@ public class HtmlImageRenderTool {
 
         log.info("[HtmlImageRender] rendered {} ({} bytes, viewport={}x{}, fullPage={})",
                 displayName, pngBytes.length, vw, vh, full);
-        return GeneratedFileLink.resultZh(pngBytes, displayName, PNG_MIME, cache, "图片", ctx);
+        return GeneratedFileLink.resultZh(pngBytes, displayName, PNG_MIME, cache, "图片", ctx, artifactService);
     }
 
     private String resolveHtml(String filePath, String inlineHtml) throws Exception {

--- a/mateclaw-server/src/main/java/vip/mate/tool/builtin/PdfRenderTool.java
+++ b/mateclaw-server/src/main/java/vip/mate/tool/builtin/PdfRenderTool.java
@@ -15,6 +15,7 @@ import vip.mate.tool.document.MarkdownInputResolver.Resolved;
 import vip.mate.tool.document.MarkdownInputResolver.ResolveException;
 import vip.mate.tool.document.pdf.MarkdownPdfRenderer;
 import vip.mate.tool.document.pdf.PdfProperties;
+import vip.mate.workspace.artifact.service.WorkspaceArtifactService;
 
 import java.util.Locale;
 
@@ -34,6 +35,7 @@ public class PdfRenderTool {
 
     private final MarkdownPdfRenderer renderer;
     private final GeneratedFileCache cache;
+    private final WorkspaceArtifactService artifactService;
 
     @Tool(description = """
         Render a NEW .pdf file from Markdown and return a one-time download URL.
@@ -100,7 +102,7 @@ public class PdfRenderTool {
             MarkdownPdfRenderer.Result result = renderer.render(markdown, size, eng);
             log.info("[PdfRender] generated {} ({} bytes via {})",
                     displayName, result.bytes().length, result.backend());
-            return GeneratedFileLink.resultZh(result.bytes(), displayName, PDF_MIME, cache, "PDF", ctx);
+            return GeneratedFileLink.resultZh(result.bytes(), displayName, PDF_MIME, cache, "PDF", ctx, artifactService);
         } catch (Exception e) {
             log.error("[PdfRender] render failed for {}: {}", displayName, e.getMessage(), e);
             return "渲染失败：" + e.getMessage();
@@ -153,7 +155,7 @@ public class PdfRenderTool {
             MarkdownPdfRenderer.Result result = renderer.render(input.markdown(), size, eng);
             log.info("[PdfRender] generated {} ({} bytes via {} from {} bytes md)",
                     displayName, result.bytes().length, result.backend(), input.totalBytes());
-            return GeneratedFileLink.resultEn(result.bytes(), displayName, PDF_MIME, cache, "Document", 1, ctx);
+            return GeneratedFileLink.resultEn(result.bytes(), displayName, PDF_MIME, cache, "Document", 1, ctx, artifactService);
         } catch (Exception e) {
             log.error("[PdfRender] render failed for {} (source: {}): {}",
                     displayName, input.sources().get(0), e.getMessage(), e);

--- a/mateclaw-server/src/main/java/vip/mate/tool/builtin/PptxRenderTool.java
+++ b/mateclaw-server/src/main/java/vip/mate/tool/builtin/PptxRenderTool.java
@@ -14,6 +14,7 @@ import vip.mate.tool.document.MarkdownInputResolver;
 import vip.mate.tool.document.MarkdownInputResolver.Resolved;
 import vip.mate.tool.document.MarkdownInputResolver.ResolveException;
 import vip.mate.tool.document.MarkdownPptxRenderer;
+import vip.mate.workspace.artifact.service.WorkspaceArtifactService;
 
 /**
  * Render a brand-new .pptx deck from Markdown, in-process via Apache POI.
@@ -31,6 +32,7 @@ public class PptxRenderTool {
 
     private final MarkdownPptxRenderer renderer;
     private final GeneratedFileCache cache;
+    private final WorkspaceArtifactService artifactService;
 
     @Tool(description = """
         Render a NEW .pptx slide deck from Markdown and return a one-time download URL.
@@ -91,7 +93,7 @@ public class PptxRenderTool {
             byte[] bytes = renderer.render(markdown, ratio);
             log.info("[PptxRender] generated {} ({} bytes, {}ms)",
                     displayName, bytes.length, System.currentTimeMillis() - t0);
-            return GeneratedFileLink.resultZh(bytes, displayName, PPTX_MIME, cache, "演示文稿", ctx);
+            return GeneratedFileLink.resultZh(bytes, displayName, PPTX_MIME, cache, "演示文稿", ctx, artifactService);
         } catch (Exception e) {
             log.error("[PptxRender] render failed for {}: {}", displayName, e.getMessage(), e);
             return "渲染失败：" + e.getMessage();
@@ -139,7 +141,7 @@ public class PptxRenderTool {
             log.info("[PptxRender] generated {} ({} bytes from {} bytes md, {}ms)",
                     displayName, bytes.length, input.totalBytes(),
                     System.currentTimeMillis() - t0);
-            return GeneratedFileLink.resultEn(bytes, displayName, PPTX_MIME, cache, "Presentation", 1, ctx);
+            return GeneratedFileLink.resultEn(bytes, displayName, PPTX_MIME, cache, "Presentation", 1, ctx, artifactService);
         } catch (Exception e) {
             log.error("[PptxRender] render failed for {} (source: {}): {}",
                     displayName, input.sources().get(0), e.getMessage(), e);

--- a/mateclaw-server/src/main/java/vip/mate/tool/builtin/ScreenshotTool.java
+++ b/mateclaw-server/src/main/java/vip/mate/tool/builtin/ScreenshotTool.java
@@ -22,6 +22,7 @@ import vip.mate.tool.browser.BrowserLauncher;
 import vip.mate.tool.document.FilenameSanitizer;
 import vip.mate.tool.document.GeneratedFileCache;
 import vip.mate.tool.document.GeneratedFileLink;
+import vip.mate.workspace.artifact.service.WorkspaceArtifactService;
 
 /**
  * Built-in tool: capture a screenshot of a MateClaw admin-console page and
@@ -55,6 +56,7 @@ public class ScreenshotTool {
 
     private final GeneratedFileCache cache;
     private final AuthService authService;
+    private final WorkspaceArtifactService artifactService;
 
     @Value("${server.port:18088}")
     private int serverPort;
@@ -112,7 +114,7 @@ public class ScreenshotTool {
         }
 
         log.info("[Screenshot] captured {} ({} bytes, fullPage={})", p, png.length, full);
-        return GeneratedFileLink.resultZh(png, displayName, PNG_MIME, cache, "截图", ctx);
+        return GeneratedFileLink.resultZh(png, displayName, PNG_MIME, cache, "截图", ctx, artifactService);
     }
 
     private byte[] render(String url, String token, boolean fullPage, int settleMs) {

--- a/mateclaw-server/src/main/java/vip/mate/tool/builtin/ShellExecuteTool.java
+++ b/mateclaw-server/src/main/java/vip/mate/tool/builtin/ShellExecuteTool.java
@@ -10,6 +10,7 @@ import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Component;
 import vip.mate.tool.document.GeneratedFileCache;
 import vip.mate.tool.document.WorkspaceArtifactSurfacer;
+import vip.mate.workspace.artifact.service.WorkspaceArtifactService;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -45,6 +46,7 @@ public class ShellExecuteTool {
 
     private final vip.mate.i18n.I18nService i18n;
     private final GeneratedFileCache generatedFileCache;
+    private final WorkspaceArtifactService artifactService;
 
     private static final int DEFAULT_TIMEOUT_SECONDS = 60;
     private static final int MAX_OUTPUT_BYTES = 10_000;
@@ -140,7 +142,7 @@ public class ShellExecuteTool {
                 // as execute_code). A single newline-joined string, not a JSON array,
                 // so the link-extraction regex captures the clean filename.
                 java.nio.file.Path workingDir = vip.mate.tool.guard.WorkspacePathGuard.getWorkingDirectory(ctx);
-                List<String> fileLinks = WorkspaceArtifactSurfacer.collect(generatedFileCache, workingDir, runStart, ctx);
+                List<String> fileLinks = WorkspaceArtifactSurfacer.collect(generatedFileCache, workingDir, runStart, ctx, artifactService);
                 if (!fileLinks.isEmpty()) {
                     result.set("generatedFiles", String.join("\n", fileLinks));
                 }

--- a/mateclaw-server/src/main/java/vip/mate/tool/builtin/XhsPublishTool.java
+++ b/mateclaw-server/src/main/java/vip/mate/tool/builtin/XhsPublishTool.java
@@ -12,6 +12,7 @@ import vip.mate.tool.browser.UrlSafetyChecker;
 import vip.mate.tool.document.GeneratedFileCache;
 import vip.mate.tool.document.GeneratedFileLink;
 import vip.mate.tool.guard.WorkspacePathGuard;
+import vip.mate.workspace.artifact.service.WorkspaceArtifactService;
 
 import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
@@ -49,6 +50,7 @@ public class XhsPublishTool {
     private static final int MAX_IMAGES = 18; // Xiaohongshu allows up to 18 images per note.
 
     private final GeneratedFileCache cache;
+    private final WorkspaceArtifactService artifactService;
 
     @Tool(name = "xhs_publish", description = """
         Package a Xiaohongshu (小红书) note into one downloadable bundle and give
@@ -121,7 +123,7 @@ public class XhsPublishTool {
         }
 
         String linkMsg = GeneratedFileLink.resultZh(
-                zip, "小红书发布包.zip", "application/zip", cache, "发布包", ctx);
+                zip, "小红书发布包.zip", "application/zip", cache, "发布包", ctx, artifactService);
 
         StringBuilder out = new StringBuilder();
         out.append(linkMsg).append("\n\n");

--- a/mateclaw-server/src/main/java/vip/mate/tool/builtin/XlsxRenderTool.java
+++ b/mateclaw-server/src/main/java/vip/mate/tool/builtin/XlsxRenderTool.java
@@ -14,6 +14,7 @@ import vip.mate.tool.document.MarkdownInputResolver;
 import vip.mate.tool.document.MarkdownInputResolver.Resolved;
 import vip.mate.tool.document.MarkdownInputResolver.ResolveException;
 import vip.mate.tool.document.MarkdownXlsxRenderer;
+import vip.mate.workspace.artifact.service.WorkspaceArtifactService;
 
 /**
  * Render a brand-new .xlsx workbook from a Markdown body, in-process via
@@ -31,6 +32,7 @@ public class XlsxRenderTool {
 
     private final MarkdownXlsxRenderer renderer;
     private final GeneratedFileCache cache;
+    private final WorkspaceArtifactService artifactService;
 
     @Tool(description = """
         Render a NEW .xlsx workbook from Markdown and return a one-time download URL.
@@ -82,7 +84,7 @@ public class XlsxRenderTool {
             byte[] bytes = renderer.render(markdown);
             log.info("[XlsxRender] generated {} ({} bytes, {}ms)",
                     displayName, bytes.length, System.currentTimeMillis() - t0);
-            return GeneratedFileLink.resultZh(bytes, displayName, XLSX_MIME, cache, "工作簿", ctx);
+            return GeneratedFileLink.resultZh(bytes, displayName, XLSX_MIME, cache, "工作簿", ctx, artifactService);
         } catch (Exception e) {
             log.error("[XlsxRender] render failed for {}: {}", displayName, e.getMessage(), e);
             return "渲染失败：" + e.getMessage();
@@ -127,7 +129,7 @@ public class XlsxRenderTool {
             log.info("[XlsxRender] generated {} ({} bytes from {} bytes md, {}ms)",
                     displayName, bytes.length, input.totalBytes(),
                     System.currentTimeMillis() - t0);
-            return GeneratedFileLink.resultEn(bytes, displayName, XLSX_MIME, cache, "Workbook", 1, ctx);
+            return GeneratedFileLink.resultEn(bytes, displayName, XLSX_MIME, cache, "Workbook", 1, ctx, artifactService);
         } catch (Exception e) {
             log.error("[XlsxRender] render failed for {} (source: {}): {}",
                     displayName, input.sources().get(0), e.getMessage(), e);

--- a/mateclaw-server/src/main/java/vip/mate/tool/document/GeneratedFileCache.java
+++ b/mateclaw-server/src/main/java/vip/mate/tool/document/GeneratedFileCache.java
@@ -132,9 +132,19 @@ public class GeneratedFileCache {
         }
     }
 
-    public record Entry(byte[] bytes, String filename, String mimeType, long expireAt) {
+    public record Entry(byte[] bytes, String filename, String mimeType, long expireAt,
+                        boolean persistent) {
+
+        public Entry(byte[] bytes, String filename, String mimeType, long expireAt) {
+            this(bytes, filename, mimeType, expireAt, false);
+        }
 
         public boolean expired() {
+            // Persistent entries never expire — they were registered into an
+            // Agent's workspace (issue #514) and must survive the TTL sweep.
+            if (persistent) {
+                return false;
+            }
             return System.currentTimeMillis() > expireAt;
         }
     }
@@ -145,13 +155,29 @@ public class GeneratedFileCache {
      * {@code /api/v1/files/generated/{id}}.
      */
     public String put(byte[] bytes, String filename, String mimeType) {
+        return put(bytes, filename, mimeType, false);
+    }
+
+    /**
+     * Store bytes that have been registered into an Agent's workspace catalog
+     * (issue #514). A persistent entry is exempt from the {@link #TTL} sweep so
+     * the download link stays live for the lifetime of the workspace — not 7
+     * days. Returns the id, or {@code null} if persistence failed (the caller
+     * treats a {@code null} id as "not registered" and falls back to the
+     * standard TTL path).
+     */
+    public String putPersistent(byte[] bytes, String filename, String mimeType) {
+        return put(bytes, filename, mimeType, true);
+    }
+
+    private String put(byte[] bytes, String filename, String mimeType, boolean persistent) {
         String id = UUID.randomUUID().toString();
         long expireAt = System.currentTimeMillis() + TTL.toMillis();
-        Entry entry = new Entry(bytes, filename, mimeType, expireAt);
+        Entry entry = new Entry(bytes, filename, mimeType, expireAt, persistent);
         entries.put(id, entry);
         persist(id, entry);
-        log.debug("Cached generated file id={} filename={} bytes={}", id, filename,
-                bytes != null ? bytes.length : 0);
+        log.debug("Cached generated file id={} filename={} bytes={} persistent={}",
+                id, filename, bytes != null ? bytes.length : 0, persistent);
         return id;
     }
 
@@ -279,8 +305,13 @@ public class GeneratedFileCache {
         long now = System.currentTimeMillis();
         for (Path metaPath : metas) {
             try {
-                String[] parts = Files.readString(metaPath).split("\t", 3);
-                if (Long.parseLong(parts[0].trim()) <= now) {
+                // split limit 4: issue #514 added a 4th field (persistent flag);
+                // older 3-field metas still parse (absent fields default).
+                String[] parts = Files.readString(metaPath).split("\t", 4);
+                boolean persistent = parts.length > 3 && "1".equals(parts[3].trim());
+                // Persistent entries never expire (issue #514); transient ones
+                // are skipped once their expireAt has passed.
+                if (!persistent && Long.parseLong(parts[0].trim()) <= now) {
                     continue;
                 }
                 String mime = parts.length > 1 && !parts[1].isEmpty() ? parts[1] : null;
@@ -307,12 +338,16 @@ public class GeneratedFileCache {
         }
         try {
             Files.write(storageDir.resolve(id), entry.bytes());
-            // expireAt \t mimeType \t base64(filename) — filename is base64-encoded
-            // so arbitrary unicode / separators round-trip without escaping.
+            // expireAt \t mimeType \t base64(filename) \t persistent
+            // — filename is base64-encoded so arbitrary unicode / separators
+            //   round-trip without escaping.
+            // — persistent ("1"/"0") was added in issue #514; older metas have
+            //   only 3 fields and default to non-persistent on read.
             String meta = entry.expireAt()
                     + "\t" + (entry.mimeType() == null ? "" : entry.mimeType())
                     + "\t" + Base64.getEncoder().encodeToString(
-                            (entry.filename() == null ? "" : entry.filename()).getBytes(StandardCharsets.UTF_8));
+                            (entry.filename() == null ? "" : entry.filename()).getBytes(StandardCharsets.UTF_8))
+                    + "\t" + (entry.persistent() ? "1" : "0");
             Files.writeString(storageDir.resolve(id + META_SUFFIX), meta);
         } catch (IOException e) {
             // Best-effort: an in-memory entry still serves the current process.
@@ -328,14 +363,17 @@ public class GeneratedFileCache {
             return null;
         }
         try {
-            String[] parts = Files.readString(meta).split("\t", 3);
+            String[] parts = Files.readString(meta).split("\t", 4);
             long expireAt = Long.parseLong(parts[0].trim());
             String mimeType = parts.length > 1 && !parts[1].isEmpty() ? parts[1] : null;
             String filename = parts.length > 2 && !parts[2].isEmpty()
                     ? new String(Base64.getDecoder().decode(parts[2]), StandardCharsets.UTF_8)
                     : id;
+            // 4th field (issue #514): "1" = persistent (workspace artifact).
+            // Absent in pre-#514 metas → defaults to false (TTL-governed).
+            boolean persistent = parts.length > 3 && "1".equals(parts[3].trim());
             byte[] bytes = Files.readAllBytes(bin);
-            return new Entry(bytes, filename, mimeType, expireAt);
+            return new Entry(bytes, filename, mimeType, expireAt, persistent);
         } catch (Exception e) {
             log.warn("Could not load generated file id={}: {}", id, e.toString());
             return null;
@@ -354,14 +392,18 @@ public class GeneratedFileCache {
 
     /**
      * Drop expired entries from memory and disk. Runs on a fixed delay; also
-     * sweeps orphaned files left by an unclean shutdown.
+     * sweeps orphaned files left by an unclean shutdown. Persistent entries
+     * (issue #514 workspace artifacts) are never swept — they are exempt from
+     * the TTL so the workspace catalog's download links stay live.
      */
     @Scheduled(fixedDelay = CLEANUP_INTERVAL_MS, initialDelay = CLEANUP_INTERVAL_MS)
     public void cleanupExpired() {
         long now = System.currentTimeMillis();
         // entrySet() of a synchronizedMap must be iterated while holding its lock.
+        // Persistent entries are excluded: Entry.expired() already returns false
+        // for them, so this removeIf is automatically safe.
         synchronized (entries) {
-            entries.entrySet().removeIf(e -> e.getValue().expireAt() <= now);
+            entries.entrySet().removeIf(e -> e.getValue().expired());
         }
         if (!Files.isDirectory(storageDir)) {
             return;
@@ -372,9 +414,12 @@ public class GeneratedFileCache {
                         String name = metaPath.getFileName().toString();
                         String id = name.substring(0, name.length() - META_SUFFIX.length());
                         try {
-                            long expireAt = Long.parseLong(
-                                    Files.readString(metaPath).split("\t", 2)[0].trim());
-                            if (expireAt <= now) {
+                            String[] parts = Files.readString(metaPath).split("\t", 4);
+                            long expireAt = Long.parseLong(parts[0].trim());
+                            boolean persistent = parts.length > 3 && "1".equals(parts[3].trim());
+                            // Persistent entries survive the sweep (issue #514);
+                            // everything else with a passed expiry is evicted.
+                            if (!persistent && expireAt <= now) {
                                 evict(id);
                             }
                         } catch (Exception e) {

--- a/mateclaw-server/src/main/java/vip/mate/tool/document/GeneratedFileCache.java
+++ b/mateclaw-server/src/main/java/vip/mate/tool/document/GeneratedFileCache.java
@@ -162,9 +162,8 @@ public class GeneratedFileCache {
      * Store bytes that have been registered into an Agent's workspace catalog
      * (issue #514). A persistent entry is exempt from the {@link #TTL} sweep so
      * the download link stays live for the lifetime of the workspace — not 7
-     * days. Returns the id, or {@code null} if persistence failed (the caller
-     * treats a {@code null} id as "not registered" and falls back to the
-     * standard TTL path).
+     * days. Always returns a non-null id (disk-write failures are best-effort:
+     * the in-memory entry still serves the current process, same as {@link #put}).
      */
     public String putPersistent(byte[] bytes, String filename, String mimeType) {
         return put(bytes, filename, mimeType, true);

--- a/mateclaw-server/src/main/java/vip/mate/tool/document/GeneratedFileLink.java
+++ b/mateclaw-server/src/main/java/vip/mate/tool/document/GeneratedFileLink.java
@@ -122,15 +122,17 @@ public final class GeneratedFileLink {
         }
         ChatOrigin origin = ChatOrigin.from(ctx);
         Long agentId = origin.agentId();
-        // No agent → not a workspace artifact (cron/test render). Skip silently.
-        if (agentId == null) {
+        // No agent/workspace → not a workspace artifact (cron/test render).
+        // Skip silently — such files are not workspace-catalog material.
+        if (agentId == null || origin.workspaceId() == null) {
             return;
         }
         WorkspaceArtifactEntity entity = new WorkspaceArtifactEntity();
         entity.setAgentId(agentId);
-        entity.setWorkspaceId(origin.workspaceId() != null ? origin.workspaceId() : 0L);
+        entity.setWorkspaceId(origin.workspaceId());
         entity.setChannelId(origin.channelId());
         entity.setConversationId(origin.conversationId());
+        entity.setSessionLabel(extractSessionLabel(origin.conversationId()));
         entity.setToolCallId(ChatOrigin.toolCallId(ctx));
         entity.setToolName(ChatOrigin.toolName(ctx));
         entity.setSource(WorkspaceArtifactService.SOURCE_AGENT);
@@ -140,10 +142,35 @@ public final class GeneratedFileLink {
         entity.setSizeBytes(bytes != null ? (long) bytes.length : 0L);
         entity.setStorageKind(storageKind);
         entity.setStorageRef(cacheId);
-        entity.setDownloadUrl(GeneratedFileCache.DOWNLOAD_PATH_PREFIX + cacheId);
+        // downloadUrl is NOT set here — WorkspaceArtifactService.toVO() builds it
+        // at read time from the artifact id, so it is always correct.
         service.register(entity);
     }
 
     /** Internal: the cache id + resolved download URL produced by a stash. */
     private record ArtifactRef(String id, String url) {}
+
+    /**
+     * Extract the human-facing session label from a server-derived
+     * conversationId of the form {@code webchat:{key8}:{visitorId}:{sessionId}}.
+     * Returns the full conversationId when it does not match the webchat shape
+     * (non-webchat origins, hashed ids).
+     */
+    static String extractSessionLabel(@Nullable String conversationId) {
+        if (conversationId == null || conversationId.isBlank()) {
+            return null;
+        }
+        // webchat:{key8}:{visitorId}:{sessionId} → sessionId is the 4th segment.
+        // Non-webchat or hashed conversationIds won't match; return them as-is
+        // so the consumer at least sees a non-null provenance label.
+        if (conversationId.startsWith("webchat:")) {
+            int first = conversationId.indexOf(':');
+            int second = conversationId.indexOf(':', first + 1);
+            int third = conversationId.indexOf(':', second + 1);
+            if (third > 0 && third < conversationId.length() - 1) {
+                return conversationId.substring(third + 1);
+            }
+        }
+        return conversationId;
+    }
 }

--- a/mateclaw-server/src/main/java/vip/mate/tool/document/GeneratedFileLink.java
+++ b/mateclaw-server/src/main/java/vip/mate/tool/document/GeneratedFileLink.java
@@ -132,7 +132,12 @@ public final class GeneratedFileLink {
         entity.setWorkspaceId(origin.workspaceId());
         entity.setChannelId(origin.channelId());
         entity.setConversationId(origin.conversationId());
-        entity.setSessionLabel(extractSessionLabel(origin.conversationId()));
+        // Store the conversationId as the provenance label. We deliberately do
+        // not parse the conversationId for a "clean" sessionId because visitorId
+        // may legally contain colons (VISITOR_ID_PATTERN allows ':'), making
+        // colon-based splitting ambiguous. The consumer filters by sessionId via
+        // the list endpoint, which re-derives the same conversationId server-side.
+        entity.setSessionLabel(origin.conversationId());
         entity.setToolCallId(ChatOrigin.toolCallId(ctx));
         entity.setToolName(ChatOrigin.toolName(ctx));
         entity.setSource(WorkspaceArtifactService.SOURCE_AGENT);
@@ -149,28 +154,4 @@ public final class GeneratedFileLink {
 
     /** Internal: the cache id + resolved download URL produced by a stash. */
     private record ArtifactRef(String id, String url) {}
-
-    /**
-     * Extract the human-facing session label from a server-derived
-     * conversationId of the form {@code webchat:{key8}:{visitorId}:{sessionId}}.
-     * Returns the full conversationId when it does not match the webchat shape
-     * (non-webchat origins, hashed ids).
-     */
-    static String extractSessionLabel(@Nullable String conversationId) {
-        if (conversationId == null || conversationId.isBlank()) {
-            return null;
-        }
-        // webchat:{key8}:{visitorId}:{sessionId} → sessionId is the 4th segment.
-        // Non-webchat or hashed conversationIds won't match; return them as-is
-        // so the consumer at least sees a non-null provenance label.
-        if (conversationId.startsWith("webchat:")) {
-            int first = conversationId.indexOf(':');
-            int second = conversationId.indexOf(':', first + 1);
-            int third = conversationId.indexOf(':', second + 1);
-            if (third > 0 && third < conversationId.length() - 1) {
-                return conversationId.substring(third + 1);
-            }
-        }
-        return conversationId;
-    }
 }

--- a/mateclaw-server/src/main/java/vip/mate/tool/document/GeneratedFileLink.java
+++ b/mateclaw-server/src/main/java/vip/mate/tool/document/GeneratedFileLink.java
@@ -2,6 +2,9 @@ package vip.mate.tool.document;
 
 import org.springframework.ai.chat.model.ToolContext;
 import org.springframework.lang.Nullable;
+import vip.mate.agent.context.ChatOrigin;
+import vip.mate.workspace.artifact.model.WorkspaceArtifactEntity;
+import vip.mate.workspace.artifact.service.WorkspaceArtifactService;
 
 /**
  * Stash freshly-rendered bytes into the {@link GeneratedFileCache} and format
@@ -13,6 +16,12 @@ import org.springframework.lang.Nullable;
  * stripping nor inventing a host — because the URL may already be absolute
  * (when {@code mateclaw.server.public-base-url} is set or a request host is
  * resolvable) and models otherwise tamper with it when echoing it back.
+ *
+ * <p>When a {@link WorkspaceArtifactService} is supplied (issue #514), the
+ * produced file is also registered into the Agent's workspace catalog as a
+ * persistent, cross-session artifact with provenance (conversationId /
+ * toolCallId) read from the {@link ToolContext}. Registration is best-effort
+ * and never fails the render.
  */
 public final class GeneratedFileLink {
 
@@ -27,10 +36,24 @@ public final class GeneratedFileLink {
     public static String resultZh(byte[] bytes, String displayName, String mimeType,
                                   GeneratedFileCache cache, String typeLabel,
                                   @Nullable ToolContext ctx) {
-        String url = stash(bytes, displayName, mimeType, cache, ctx);
-        return typeLabel + "已生成：[" + displayName + "](" + url + ")（链接 "
+        return resultZh(bytes, displayName, mimeType, cache, typeLabel, ctx, null);
+    }
+
+    /**
+     * Chinese-language variant that also registers the file as a workspace
+     * artifact (issue #514).
+     *
+     * @param artifactService if non-null, the file is registered as a persistent
+     *                        cross-session artifact with provenance from {@code ctx}
+     */
+    public static String resultZh(byte[] bytes, String displayName, String mimeType,
+                                  GeneratedFileCache cache, String typeLabel,
+                                  @Nullable ToolContext ctx,
+                                  @Nullable WorkspaceArtifactService artifactService) {
+        ArtifactRef ref = stash(bytes, displayName, mimeType, cache, ctx, artifactService);
+        return typeLabel + "已生成：[" + displayName + "](" + ref.url() + ")（链接 "
                 + GeneratedFileCache.TTL.toDays() + " 天内有效）。\n"
-                + "重要：回答用户时**必须**使用上述 markdown 链接格式 [" + displayName + "](" + url + ")，"
+                + "重要：回答用户时**必须**使用上述 markdown 链接格式 [" + displayName + "](" + ref.url() + ")，"
                 + "保持链接地址**原样照抄**，**不要**用反引号包裹，**不要**增删任何域名或 http(s):// 前缀。";
     }
 
@@ -46,20 +69,81 @@ public final class GeneratedFileLink {
     public static String resultEn(byte[] bytes, String displayName, String mimeType,
                                   GeneratedFileCache cache, String typeLabel,
                                   int sourceFileCount, @Nullable ToolContext ctx) {
-        String url = stash(bytes, displayName, mimeType, cache, ctx);
+        return resultEn(bytes, displayName, mimeType, cache, typeLabel, sourceFileCount, ctx, null);
+    }
+
+    /**
+     * English-language variant that also registers the file as a workspace
+     * artifact (issue #514).
+     */
+    public static String resultEn(byte[] bytes, String displayName, String mimeType,
+                                  GeneratedFileCache cache, String typeLabel,
+                                  int sourceFileCount, @Nullable ToolContext ctx,
+                                  @Nullable WorkspaceArtifactService artifactService) {
+        ArtifactRef ref = stash(bytes, displayName, mimeType, cache, ctx, artifactService);
         String prefix = sourceFileCount > 1
                 ? typeLabel + " generated from " + sourceFileCount + " files"
                 : typeLabel + " generated";
-        return prefix + ": [" + displayName + "](" + url + ") (link valid for "
+        return prefix + ": [" + displayName + "](" + ref.url() + ") (link valid for "
                 + GeneratedFileCache.TTL.toDays() + " days).\n"
                 + "IMPORTANT: when replying to the user you **must** keep the markdown link form ["
-                + displayName + "](" + url + ") above. Copy the URL verbatim — do **not** wrap it "
+                + displayName + "](" + ref.url() + ") above. Copy the URL verbatim — do **not** wrap it "
                 + "in backticks and do **not** add or remove any https://, http:// or domain.";
     }
 
-    private static String stash(byte[] bytes, String displayName, String mimeType,
-                                GeneratedFileCache cache, @Nullable ToolContext ctx) {
-        String id = cache.put(bytes, displayName, mimeType);
-        return cache.downloadUrl(id, ctx);
+    private static ArtifactRef stash(byte[] bytes, String displayName, String mimeType,
+                                     GeneratedFileCache cache, @Nullable ToolContext ctx,
+                                     @Nullable WorkspaceArtifactService artifactService) {
+        boolean register = artifactService != null;
+        String id = register
+                ? cache.putPersistent(bytes, displayName, mimeType)
+                : cache.put(bytes, displayName, mimeType);
+        String url = cache.downloadUrl(id, ctx);
+        if (register) {
+            registerArtifact(artifactService, id, bytes, displayName, mimeType, ctx,
+                    WorkspaceArtifactService.STORAGE_GENERATED_CACHE);
+        }
+        return new ArtifactRef(id, url);
     }
+
+    /**
+     * Best-effort artifact registration. Reads provenance (agentId /
+     * workspaceId / channelId / conversationId / toolCallId / toolName) from the
+     * {@link ChatOrigin} + tool-context keys stamped by {@code ToolExecutionExecutor}.
+     * Silently no-ops when the context lacks an agentId (e.g. a unit-test render)
+     * — such files are not workspace artifacts.
+     */
+    static void registerArtifact(@Nullable WorkspaceArtifactService service,
+                                 @Nullable String cacheId, byte[] bytes, String displayName,
+                                 String mimeType, @Nullable ToolContext ctx,
+                                 String storageKind) {
+        if (service == null || cacheId == null) {
+            return;
+        }
+        ChatOrigin origin = ChatOrigin.from(ctx);
+        Long agentId = origin.agentId();
+        // No agent → not a workspace artifact (cron/test render). Skip silently.
+        if (agentId == null) {
+            return;
+        }
+        WorkspaceArtifactEntity entity = new WorkspaceArtifactEntity();
+        entity.setAgentId(agentId);
+        entity.setWorkspaceId(origin.workspaceId() != null ? origin.workspaceId() : 0L);
+        entity.setChannelId(origin.channelId());
+        entity.setConversationId(origin.conversationId());
+        entity.setToolCallId(ChatOrigin.toolCallId(ctx));
+        entity.setToolName(ChatOrigin.toolName(ctx));
+        entity.setSource(WorkspaceArtifactService.SOURCE_AGENT);
+        entity.setArtifactType(WorkspaceArtifactService.classifyType(displayName, mimeType));
+        entity.setName(displayName);
+        entity.setMime(mimeType);
+        entity.setSizeBytes(bytes != null ? (long) bytes.length : 0L);
+        entity.setStorageKind(storageKind);
+        entity.setStorageRef(cacheId);
+        entity.setDownloadUrl(GeneratedFileCache.DOWNLOAD_PATH_PREFIX + cacheId);
+        service.register(entity);
+    }
+
+    /** Internal: the cache id + resolved download URL produced by a stash. */
+    private record ArtifactRef(String id, String url) {}
 }

--- a/mateclaw-server/src/main/java/vip/mate/tool/document/WorkspaceArtifactSurfacer.java
+++ b/mateclaw-server/src/main/java/vip/mate/tool/document/WorkspaceArtifactSurfacer.java
@@ -3,6 +3,7 @@ package vip.mate.tool.document;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.ai.chat.model.ToolContext;
 import org.springframework.lang.Nullable;
+import vip.mate.workspace.artifact.service.WorkspaceArtifactService;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -43,6 +44,20 @@ public final class WorkspaceArtifactSurfacer {
      */
     public static List<String> collect(GeneratedFileCache cache, @Nullable Path workingDir,
                                        long sinceMillis, @Nullable ToolContext ctx) {
+        return collect(cache, workingDir, sinceMillis, ctx, null);
+    }
+
+    /**
+     * Variant that also registers each surfaced file into the Agent's workspace
+     * catalog (issue #514). Best-effort throughout — surfacing a download must
+     * never fail the tool run, and neither must the catalog write.
+     *
+     * @param artifactService if non-null, each file is registered as a persistent
+     *                        cross-session artifact with provenance from {@code ctx}
+     */
+    public static List<String> collect(GeneratedFileCache cache, @Nullable Path workingDir,
+                                       long sinceMillis, @Nullable ToolContext ctx,
+                                       @Nullable WorkspaceArtifactService artifactService) {
         if (cache == null || workingDir == null || !Files.isDirectory(workingDir)) {
             return List.of();
         }
@@ -67,8 +82,16 @@ public final class WorkspaceArtifactSurfacer {
                     byte[] bytes = Files.readAllBytes(p);
                     totalBytes += size;
                     String name = p.getFileName().toString();
-                    String id = cache.put(bytes, name, probeMime(p, name));
+                    String mime = probeMime(p, name);
+                    boolean register = artifactService != null;
+                    String id = register
+                            ? cache.putPersistent(bytes, name, mime)
+                            : cache.put(bytes, name, mime);
                     links.add("[" + name + "](" + cache.downloadUrl(id, ctx) + ")");
+                    if (register) {
+                        GeneratedFileLink.registerArtifact(artifactService, id, bytes, name, mime,
+                                ctx, WorkspaceArtifactService.STORAGE_GENERATED_CACHE);
+                    }
                 } catch (Exception perFile) {
                     log.debug("[ArtifactSurfacer] skip {}: {}", p, perFile.getMessage());
                 }

--- a/mateclaw-server/src/main/java/vip/mate/workspace/artifact/model/WorkspaceArtifactEntity.java
+++ b/mateclaw-server/src/main/java/vip/mate/workspace/artifact/model/WorkspaceArtifactEntity.java
@@ -1,0 +1,88 @@
+package vip.mate.workspace.artifact.model;
+
+import com.baomidou.mybatisplus.annotation.FieldFill;
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableField;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+/**
+ * Agent-level artifact metadata row.
+ *
+ * <p>Catalogs every file that enters an Agent's workspace — both Agent-produced
+ * output (rendered documents, code-generated files) and user-uploaded inputs —
+ * so a WebChat consumer can list the full cross-session file inventory
+ * (issue #514). The bytes themselves live in their original store
+ * ({@code GeneratedFileCache} for agent output, the chat-uploads dir for user
+ * uploads); this row only carries provenance + the relative {@link #downloadUrl}
+ * the consumer uses to fetch the file.
+ *
+ * <p><b>Ownership model:</b> a file belongs to its Agent/Workspace, NOT to a
+ * session. {@link #conversationId} and {@link #sessionLabel} are provenance
+ * labels — deleting a conversation must not delete its artifacts.
+ */
+@Data
+@TableName("mate_workspace_artifact")
+public class WorkspaceArtifactEntity {
+
+    @TableId(type = IdType.ASSIGN_ID)
+    private Long id;
+
+    private Long workspaceId;
+
+    private Long channelId;
+
+    private Long agentId;
+
+    /** Server-derived conversation id — the storage partition key, also used
+     *  for session-filtered listing. */
+    private String conversationId;
+
+    /** The client-supplied sessionId (e.g. {@code sess_001}), kept separately
+     *  from conversationId so the consumer can show the human-facing label. */
+    private String sessionLabel;
+
+    /** Which tool call produced this file. Null for user uploads. */
+    private String toolCallId;
+
+    /** Tool bean name that produced the file (e.g. {@code docxRenderTool}).
+     *  Null for user uploads. */
+    private String toolName;
+
+    /** {@code agent} (Agent-produced) or {@code user} (user-uploaded). */
+    private String source;
+
+    /** Logical category derived from mime/extension: document / data / image /
+     *  chart / other. */
+    private String artifactType;
+
+    /** File name including extension. */
+    private String name;
+
+    private String mime;
+
+    private Long sizeBytes;
+
+    /** Which backing store holds the bytes: {@code generated_cache} (agent
+     *  output via GeneratedFileCache) or {@code upload} (user upload under the
+     *  chat-uploads dir). */
+    private String storageKind;
+
+    /** Opaque reference into the backing store — a GeneratedFileCache uuid for
+     *  {@code generated_cache}, or the storedName for {@code upload}. */
+    private String storageRef;
+
+    /** Relative download path the consumer appends to its base URL. */
+    private String downloadUrl;
+
+    @TableField(fill = FieldFill.INSERT)
+    private LocalDateTime createTime;
+
+    @TableField(fill = FieldFill.INSERT_UPDATE)
+    private LocalDateTime updateTime;
+
+    private Integer deleted;
+}

--- a/mateclaw-server/src/main/java/vip/mate/workspace/artifact/repository/WorkspaceArtifactMapper.java
+++ b/mateclaw-server/src/main/java/vip/mate/workspace/artifact/repository/WorkspaceArtifactMapper.java
@@ -1,0 +1,14 @@
+package vip.mate.workspace.artifact.repository;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import org.apache.ibatis.annotations.Mapper;
+import vip.mate.workspace.artifact.model.WorkspaceArtifactEntity;
+
+/**
+ * MyBatis-Plus mapper for {@link WorkspaceArtifactEntity}.
+ *
+ * @author MateClaw Team
+ */
+@Mapper
+public interface WorkspaceArtifactMapper extends BaseMapper<WorkspaceArtifactEntity> {
+}

--- a/mateclaw-server/src/main/java/vip/mate/workspace/artifact/service/WorkspaceArtifactService.java
+++ b/mateclaw-server/src/main/java/vip/mate/workspace/artifact/service/WorkspaceArtifactService.java
@@ -1,0 +1,172 @@
+package vip.mate.workspace.artifact.service;
+
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.baomidou.mybatisplus.core.metadata.IPage;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.lang.Nullable;
+import org.springframework.stereotype.Service;
+import vip.mate.workspace.artifact.model.WorkspaceArtifactEntity;
+import vip.mate.workspace.artifact.repository.WorkspaceArtifactMapper;
+import vip.mate.workspace.artifact.vo.ArtifactPageVO;
+import vip.mate.workspace.artifact.vo.ArtifactVO;
+
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+/**
+ * Registers files into an Agent's workspace catalog and lists them (issue #514).
+ *
+ * <p>Two sources feed the catalog:
+ * <ul>
+ *   <li>{@code agent} — files produced by document-render tools / code-execution
+ *       tools, registered via {@link GeneratedFileLink} / {@code WorkspaceArtifactSurfacer}.</li>
+ *   <li>{@code user} — files uploaded through the WebChat {@code /upload}
+ *       endpoint, registered inline in {@code WebChatController}.</li>
+ * </ul>
+ *
+ * <p>Registration is best-effort by design: a metadata-write failure must never
+ * fail the file-producing tool run or the upload — the file is already safely
+ * stored; only the catalog row is lost, which is a degraded-but-acceptable
+ * outcome (the consumer simply won't list that one file).
+ *
+ * @author MateClaw Team
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class WorkspaceArtifactService {
+
+    /** {@code source} values. */
+    public static final String SOURCE_AGENT = "agent";
+    public static final String SOURCE_USER = "user";
+
+    /** {@code storageKind} values. */
+    public static final String STORAGE_GENERATED_CACHE = "generated_cache";
+    public static final String STORAGE_UPLOAD = "upload";
+
+    /** Max page size accepted by the list endpoint. */
+    private static final int MAX_PAGE_SIZE = 200;
+    private static final int DEFAULT_PAGE_SIZE = 50;
+
+    private static final DateTimeFormatter ISO_UTC =
+            DateTimeFormatter.ISO_OFFSET_DATE_TIME.withZone(ZoneOffset.UTC);
+
+    private final WorkspaceArtifactMapper mapper;
+
+    /**
+     * Record a metadata row for an artifact. Best-effort: swallows persistence
+     * errors so the caller (a tool run or an upload) is never failed by a
+     * catalog write.
+     *
+     * @return the persisted id, or {@code null} if the write failed.
+     */
+    public Long register(WorkspaceArtifactEntity entity) {
+        try {
+            mapper.insert(entity);
+            return entity.getId();
+        } catch (Exception e) {
+            log.warn("[WorkspaceArtifact] failed to register row (name={}, conv={}): {}",
+                    entity.getName(), entity.getConversationId(), e.toString());
+            return null;
+        }
+    }
+
+    /**
+     * List artifacts for an agent's workspace, newest first, with optional
+     * provenance/category filters.
+     *
+     * @param agentId       the channel-bound agent (required)
+     * @param workspaceId   the agent's workspace (required, doubles as the
+     *                      soft tenancy boundary)
+     * @param conversationId optional session filter (server-derived conv id)
+     * @param source         optional {@code agent}/{@code user} filter
+     * @param type           optional category filter
+     * @param page           1-based page number
+     * @param size           page size
+     */
+    public ArtifactPageVO list(Long agentId, Long workspaceId,
+                               @Nullable String conversationId,
+                               @Nullable String source,
+                               @Nullable String type,
+                               int page, int size) {
+        int safePage = Math.max(1, page);
+        int safeSize = size <= 0 ? DEFAULT_PAGE_SIZE : Math.min(size, MAX_PAGE_SIZE);
+
+        LambdaQueryWrapper<WorkspaceArtifactEntity> qw = new LambdaQueryWrapper<>();
+        qw.eq(WorkspaceArtifactEntity::getAgentId, agentId);
+        qw.eq(WorkspaceArtifactEntity::getWorkspaceId, workspaceId);
+        qw.eq(WorkspaceArtifactEntity::getDeleted, 0);
+        if (conversationId != null && !conversationId.isBlank()) {
+            qw.eq(WorkspaceArtifactEntity::getConversationId, conversationId);
+        }
+        if (source != null && !source.isBlank()) {
+            qw.eq(WorkspaceArtifactEntity::getSource, source);
+        }
+        if (type != null && !type.isBlank()) {
+            qw.eq(WorkspaceArtifactEntity::getArtifactType, type);
+        }
+        qw.orderByDesc(WorkspaceArtifactEntity::getCreateTime);
+
+        IPage<WorkspaceArtifactEntity> mpPage = new Page<>(safePage, safeSize);
+        IPage<WorkspaceArtifactEntity> result = mapper.selectPage(mpPage, qw);
+
+        List<ArtifactVO> items = result.getRecords().stream()
+                .map(WorkspaceArtifactService::toVO)
+                .toList();
+
+        return ArtifactPageVO.builder()
+                .items(items)
+                .total(result.getTotal())
+                .page(safePage)
+                .size(safeSize)
+                .hasMore(safePage * safeSize < result.getTotal())
+                .build();
+    }
+
+    /** Derive a logical category from a filename + mime type. */
+    public static String classifyType(@Nullable String name, @Nullable String mime) {
+        String lowerName = name != null ? name.toLowerCase() : "";
+        if (lowerName.endsWith(".docx") || lowerName.endsWith(".pdf")
+                || lowerName.endsWith(".pptx") || lowerName.endsWith(".doc")
+                || lowerName.endsWith(".ppt")) {
+            return "document";
+        }
+        if (lowerName.endsWith(".xlsx") || lowerName.endsWith(".csv")
+                || lowerName.endsWith(".xls")) {
+            return "data";
+        }
+        if (lowerName.endsWith(".png") || lowerName.endsWith(".jpg")
+                || lowerName.endsWith(".jpeg") || lowerName.endsWith(".gif")
+                || lowerName.endsWith(".webp") || lowerName.endsWith(".bmp")
+                || lowerName.endsWith(".svg")) {
+            return "image";
+        }
+        if (mime != null) {
+            if (mime.startsWith("image/")) return "image";
+            if (mime.contains("spreadsheet") || mime.equals("text/csv")) return "data";
+            if (mime.contains("presentation") || mime.contains("wordprocessing")
+                    || mime.equals("application/pdf")) return "document";
+        }
+        return "other";
+    }
+
+    private static ArtifactVO toVO(WorkspaceArtifactEntity e) {
+        return ArtifactVO.builder()
+                .id(String.valueOf(e.getId()))
+                .name(e.getName())
+                .source(e.getSource())
+                .type(e.getArtifactType())
+                .size(e.getSizeBytes())
+                .mime(e.getMime())
+                .downloadUrl(e.getDownloadUrl())
+                .sessionId(e.getConversationId())
+                .toolCallId(e.getToolCallId())
+                .createdAt(e.getCreateTime() != null
+                        ? ISO_UTC.format(e.getCreateTime())
+                        : null)
+                .build();
+    }
+}

--- a/mateclaw-server/src/main/java/vip/mate/workspace/artifact/service/WorkspaceArtifactService.java
+++ b/mateclaw-server/src/main/java/vip/mate/workspace/artifact/service/WorkspaceArtifactService.java
@@ -51,6 +51,14 @@ public class WorkspaceArtifactService {
     private static final int MAX_PAGE_SIZE = 200;
     private static final int DEFAULT_PAGE_SIZE = 50;
 
+    /**
+     * Base path of the workspace-scoped download endpoint (issue #514). The
+     * downloadUrl in VOs is built from the artifact id at read time so it is
+     * always correct regardless of when the row was written — there is no
+     * id-bearing URL to get stale at insert time.
+     */
+    public static final String DOWNLOAD_PATH_PREFIX = "/api/v1/channels/webchat/artifacts/";
+
     private static final DateTimeFormatter ISO_UTC =
             DateTimeFormatter.ISO_OFFSET_DATE_TIME.withZone(ZoneOffset.UTC);
 
@@ -72,6 +80,19 @@ public class WorkspaceArtifactService {
                     entity.getName(), entity.getConversationId(), e.toString());
             return null;
         }
+    }
+
+    /**
+     * Look up a single artifact by id. Used by the download endpoint to resolve
+     * the backing-store reference without coupling to session-scoped resolution.
+     *
+     * @return the entity, or {@code null} if not found / soft-deleted.
+     */
+    public WorkspaceArtifactEntity findById(Long id) {
+        if (id == null) {
+            return null;
+        }
+        return mapper.selectById(id);
     }
 
     /**
@@ -154,6 +175,12 @@ public class WorkspaceArtifactService {
     }
 
     private static ArtifactVO toVO(WorkspaceArtifactEntity e) {
+        // Prefer the human-facing session label (sess_001) for the consumer; fall
+        // back to the server-derived conversationId when no label was recorded
+        // (shouldn't happen for webchat, but guards against cron/test origins).
+        String sessionId = e.getSessionLabel() != null && !e.getSessionLabel().isBlank()
+                ? e.getSessionLabel()
+                : e.getConversationId();
         return ArtifactVO.builder()
                 .id(String.valueOf(e.getId()))
                 .name(e.getName())
@@ -161,8 +188,11 @@ public class WorkspaceArtifactService {
                 .type(e.getArtifactType())
                 .size(e.getSizeBytes())
                 .mime(e.getMime())
-                .downloadUrl(e.getDownloadUrl())
-                .sessionId(e.getConversationId())
+                // Build the download URL at read time from the id — it is always
+                // correct regardless of when the row was inserted (issue #514
+                // review fix). The row's own downloadUrl column is not used.
+                .downloadUrl(DOWNLOAD_PATH_PREFIX + e.getId() + "/download")
+                .sessionId(sessionId)
                 .toolCallId(e.getToolCallId())
                 .createdAt(e.getCreateTime() != null
                         ? ISO_UTC.format(e.getCreateTime())

--- a/mateclaw-server/src/main/java/vip/mate/workspace/artifact/vo/ArtifactPageVO.java
+++ b/mateclaw-server/src/main/java/vip/mate/workspace/artifact/vo/ArtifactPageVO.java
@@ -1,0 +1,31 @@
+package vip.mate.workspace.artifact.vo;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+/**
+ * Paginated artifact listing (issue #514).
+ *
+ * <p>Deliberately a plain VO rather than a MyBatis-Plus {@code IPage} so the
+ * external contract ({@code total / page / size / hasMore}) is stable and
+ * decoupled from the ORM's page type — the WebChat consumer deserialises this
+ * without pulling in MyBatis-Plus.
+ *
+ * @author MateClaw Team
+ */
+@Data
+@Builder
+public class ArtifactPageVO {
+
+    private List<ArtifactVO> items;
+
+    private long total;
+
+    private int page;
+
+    private int size;
+
+    private boolean hasMore;
+}

--- a/mateclaw-server/src/main/java/vip/mate/workspace/artifact/vo/ArtifactVO.java
+++ b/mateclaw-server/src/main/java/vip/mate/workspace/artifact/vo/ArtifactVO.java
@@ -1,0 +1,51 @@
+package vip.mate.workspace.artifact.vo;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+import lombok.Data;
+
+/**
+ * Consumer-facing representation of a workspace artifact (issue #514).
+ *
+ * <p>Strips internal storage details ({@code storageKind}/{@code storageRef})
+ * and exposes only what the WebChat panel needs: identity, provenance, and a
+ * relative {@link #downloadUrl}. The {@link #id} is returned as a string so the
+ * snowflake BIGINT survives JS number precision loss in the browser.
+ *
+ * @author MateClaw Team
+ */
+@Data
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ArtifactVO {
+
+    /** Artifact id (stringified snowflake). */
+    private String id;
+
+    /** File name including extension. */
+    private String name;
+
+    /** {@code agent} (Agent-produced) or {@code user} (user-uploaded). */
+    private String source;
+
+    /** Logical category: document / data / image / chart / other. */
+    private String type;
+
+    /** Size in bytes. */
+    private Long size;
+
+    /** MIME type. */
+    private String mime;
+
+    /** Relative download path (consumer prepends its base URL). */
+    private String downloadUrl;
+
+    /** Provenance: which session produced/received this file. */
+    private String sessionId;
+
+    /** Provenance: which tool call produced this file (null for user uploads). */
+    private String toolCallId;
+
+    /** ISO-8601 creation timestamp (UTC). */
+    private String createdAt;
+}

--- a/mateclaw-server/src/main/resources/db/migration/h2/V170__workspace_artifact.sql
+++ b/mateclaw-server/src/main/resources/db/migration/h2/V170__workspace_artifact.sql
@@ -1,0 +1,41 @@
+-- V170: Agent-level workspace artifacts — persistent, cross-session file metadata.
+-- Tracks every file an Agent produces (source=agent) and every file a user
+-- uploads (source=user) so the WebChat consumer (ATLAS) can list the full
+-- workspace file inventory across sessions. Files live at the Agent/Workspace
+-- level; sessions are only a provenance label, not an ownership container.
+--
+-- See GitHub issue #514. The actual file bytes stay in their existing storage
+-- (GeneratedFileCache for agent output, the chat-uploads dir for user uploads);
+-- this table only holds the catalog/provenance metadata + the relative
+-- download URL the consumer uses to fetch each file.
+
+CREATE TABLE IF NOT EXISTS mate_workspace_artifact (
+    id              BIGINT       NOT NULL PRIMARY KEY,
+    workspace_id    BIGINT       NOT NULL,
+    channel_id      BIGINT,
+    agent_id        BIGINT,
+    conversation_id VARCHAR(128),
+    session_label   VARCHAR(128),
+    tool_call_id    VARCHAR(128),
+    tool_name       VARCHAR(128),
+    source          VARCHAR(16)  NOT NULL,
+    artifact_type   VARCHAR(32),
+    name            VARCHAR(512) NOT NULL,
+    mime            VARCHAR(256),
+    size_bytes      BIGINT,
+    storage_kind    VARCHAR(16)  NOT NULL,
+    storage_ref     VARCHAR(512) NOT NULL,
+    download_url    VARCHAR(512) NOT NULL,
+    create_time     TIMESTAMP    NULL DEFAULT CURRENT_TIMESTAMP,
+    update_time     TIMESTAMP    NULL DEFAULT CURRENT_TIMESTAMP,
+    deleted         INT          NOT NULL DEFAULT 0
+);
+
+-- Primary access path: "list this agent's artifacts, newest first" (the list
+-- endpoint's hot query). Composite on agent_id + deleted keeps the listing
+-- index selective even when a soft-delete accumulates.
+CREATE INDEX IF NOT EXISTS idx_wsa_agent ON mate_workspace_artifact(agent_id, deleted, create_time DESC);
+-- Session-filtered listing and per-session artifact lookup.
+CREATE INDEX IF NOT EXISTS idx_wsa_conv ON mate_workspace_artifact(conversation_id);
+-- Source filtering (agent vs user) within an agent's workspace.
+CREATE INDEX IF NOT EXISTS idx_wsa_source ON mate_workspace_artifact(agent_id, source, create_time DESC);

--- a/mateclaw-server/src/main/resources/db/migration/h2/V171__workspace_artifact_download_url_nullable.sql
+++ b/mateclaw-server/src/main/resources/db/migration/h2/V171__workspace_artifact_download_url_nullable.sql
@@ -1,0 +1,10 @@
+-- V171: Make mate_workspace_artifact.download_url nullable.
+-- The downloadUrl is now built at read time (in WorkspaceArtifactService.toVO)
+-- from the artifact id, so the column is no longer populated at insert. The
+-- original V170 migration declared it NOT NULL with no default, which silently
+-- broke every registration (the NOT_NULL insert strategy omits the null field,
+-- so the DB raised a constraint violation caught + swallowed by the
+-- best-effort register() path). Making it nullable aligns the schema with the
+-- read-time-URL design.
+
+ALTER TABLE mate_workspace_artifact ALTER COLUMN download_url DROP NOT NULL;

--- a/mateclaw-server/src/main/resources/db/migration/kingbase/V170__workspace_artifact.sql
+++ b/mateclaw-server/src/main/resources/db/migration/kingbase/V170__workspace_artifact.sql
@@ -1,0 +1,28 @@
+-- V170: Agent-level workspace artifacts — persistent, cross-session file metadata.
+-- KingbaseES / PostgreSQL dialect. See h2/V170 for design notes.
+
+CREATE TABLE IF NOT EXISTS mate_workspace_artifact (
+    id              BIGINT       NOT NULL PRIMARY KEY,
+    workspace_id    BIGINT       NOT NULL,
+    channel_id      BIGINT,
+    agent_id        BIGINT,
+    conversation_id VARCHAR(128),
+    session_label   VARCHAR(128),
+    tool_call_id    VARCHAR(128),
+    tool_name       VARCHAR(128),
+    source          VARCHAR(16)  NOT NULL,
+    artifact_type   VARCHAR(32),
+    name            VARCHAR(512) NOT NULL,
+    mime            VARCHAR(256),
+    size_bytes      BIGINT,
+    storage_kind    VARCHAR(16)  NOT NULL,
+    storage_ref     VARCHAR(512) NOT NULL,
+    download_url    VARCHAR(512) NOT NULL,
+    create_time     TIMESTAMP    NULL DEFAULT CURRENT_TIMESTAMP,
+    update_time     TIMESTAMP    NULL DEFAULT CURRENT_TIMESTAMP,
+    deleted         INT          NOT NULL DEFAULT 0
+);
+
+CREATE INDEX IF NOT EXISTS idx_wsa_agent  ON mate_workspace_artifact(agent_id, deleted, create_time DESC);
+CREATE INDEX IF NOT EXISTS idx_wsa_conv   ON mate_workspace_artifact(conversation_id);
+CREATE INDEX IF NOT EXISTS idx_wsa_source ON mate_workspace_artifact(agent_id, source, create_time DESC);

--- a/mateclaw-server/src/main/resources/db/migration/kingbase/V171__workspace_artifact_download_url_nullable.sql
+++ b/mateclaw-server/src/main/resources/db/migration/kingbase/V171__workspace_artifact_download_url_nullable.sql
@@ -1,0 +1,3 @@
+-- V171: Make mate_workspace_artifact.download_url nullable. See h2/V171.
+
+ALTER TABLE mate_workspace_artifact ALTER COLUMN download_url DROP NOT NULL;

--- a/mateclaw-server/src/main/resources/db/migration/mysql/V170__workspace_artifact.sql
+++ b/mateclaw-server/src/main/resources/db/migration/mysql/V170__workspace_artifact.sql
@@ -1,0 +1,28 @@
+-- V170: Agent-level workspace artifacts — persistent, cross-session file metadata.
+-- MySQL dialect (mirror of the h2 migration). See the h2 file for rationale.
+
+CREATE TABLE IF NOT EXISTS mate_workspace_artifact (
+    id              BIGINT       NOT NULL PRIMARY KEY,
+    workspace_id    BIGINT       NOT NULL,
+    channel_id      BIGINT       NULL,
+    agent_id        BIGINT       NULL,
+    conversation_id VARCHAR(128) NULL,
+    session_label   VARCHAR(128) NULL,
+    tool_call_id    VARCHAR(128) NULL,
+    tool_name       VARCHAR(128) NULL,
+    source          VARCHAR(16)  NOT NULL,
+    artifact_type   VARCHAR(32)  NULL,
+    name            VARCHAR(512) NOT NULL,
+    mime            VARCHAR(256) NULL,
+    size_bytes      BIGINT       NULL,
+    storage_kind    VARCHAR(16)  NOT NULL,
+    storage_ref     VARCHAR(512) NOT NULL,
+    download_url    VARCHAR(512) NOT NULL,
+    create_time     DATETIME     NULL DEFAULT CURRENT_TIMESTAMP,
+    update_time     DATETIME     NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    deleted         INT          NOT NULL DEFAULT 0
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE INDEX idx_wsa_agent  ON mate_workspace_artifact(agent_id, deleted, create_time DESC);
+CREATE INDEX idx_wsa_conv   ON mate_workspace_artifact(conversation_id);
+CREATE INDEX idx_wsa_source ON mate_workspace_artifact(agent_id, source, create_time DESC);

--- a/mateclaw-server/src/main/resources/db/migration/mysql/V171__workspace_artifact_download_url_nullable.sql
+++ b/mateclaw-server/src/main/resources/db/migration/mysql/V171__workspace_artifact_download_url_nullable.sql
@@ -1,0 +1,3 @@
+-- V171: Make mate_workspace_artifact.download_url nullable. See h2/V171.
+
+ALTER TABLE mate_workspace_artifact MODIFY download_url VARCHAR(512) NULL;

--- a/mateclaw-server/src/test/java/vip/mate/tool/builtin/CodeExecuteToolArgsTest.java
+++ b/mateclaw-server/src/test/java/vip/mate/tool/builtin/CodeExecuteToolArgsTest.java
@@ -24,7 +24,7 @@ class CodeExecuteToolArgsTest {
 
     /** Unused collaborators are null — {@code normalizeArgs} only needs the mapper. */
     private final CodeExecuteTool tool =
-            new CodeExecuteTool(null, null, null, objectMapper, null);
+            new CodeExecuteTool(null, null, null, objectMapper, null, null);
 
     @Test
     @DisplayName("null / blank / empty-array args yield no argument list")

--- a/mateclaw-server/src/test/java/vip/mate/tool/builtin/CodeExecuteToolArtifactTest.java
+++ b/mateclaw-server/src/test/java/vip/mate/tool/builtin/CodeExecuteToolArtifactTest.java
@@ -25,7 +25,7 @@ class CodeExecuteToolArtifactTest {
     @Test
     @DisplayName("formatResult embeds links so extraction yields the clean filename, not '\"[name'")
     void formatResultExtractsCleanFilename() {
-        CodeExecuteTool tool = new CodeExecuteTool(null, null, null, null, null);
+        CodeExecuteTool tool = new CodeExecuteTool(null, null, null, null, null, null);
         var result = vip.mate.skill.runtime.SkillScriptExecutionService.ScriptResult.error(0, "");
         String out = tool.formatResult(result, List.of(
                 "[report.csv](http://localhost:18088/api/v1/files/generated/abc-123)",
@@ -43,7 +43,7 @@ class CodeExecuteToolArtifactTest {
     @Test
     @DisplayName("No artifacts → no generatedFiles field")
     void noArtifactsNoField() {
-        CodeExecuteTool tool = new CodeExecuteTool(null, null, null, null, null);
+        CodeExecuteTool tool = new CodeExecuteTool(null, null, null, null, null, null);
         var result = vip.mate.skill.runtime.SkillScriptExecutionService.ScriptResult.error(0, "ok");
         String out = tool.formatResult(result, List.of());
         assertEquals(false, out.contains("generatedFiles"), out);

--- a/mateclaw-server/src/test/java/vip/mate/tool/document/GeneratedFileCachePersistentTest.java
+++ b/mateclaw-server/src/test/java/vip/mate/tool/document/GeneratedFileCachePersistentTest.java
@@ -1,0 +1,91 @@
+package vip.mate.tool.document;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Pins the issue #514 persistent-entry contract: a file registered into a
+ * workspace artifact catalog must survive the TTL sweep (and a restart) —
+ * unlike a plain {@code put} whose bytes are deleted after 7 days.
+ */
+class GeneratedFileCachePersistentTest {
+
+    @Test
+    @DisplayName("putPersistent entry is never reported as expired, even past its nominal TTL")
+    void persistentNeverExpires(@TempDir Path dir) {
+        GeneratedFileCache cache = new GeneratedFileCache(dir);
+        String id = cache.putPersistent("body".getBytes(StandardCharsets.UTF_8), "report.docx",
+                "application/vnd.openxmlformats-officedocument.wordprocessingml.document");
+
+        GeneratedFileCache.Entry entry = cache.get(id).orElse(null);
+        assertNotNull(entry, "persistent entry must be retrievable");
+        assertFalse(entry.expired(), "persistent entry must never be expired");
+        assertTrue(entry.persistent(), "persistent flag must be true");
+    }
+
+    @Test
+    @DisplayName("cleanupExpired does NOT sweep persistent entries")
+    void cleanupSkipsPersistent(@TempDir Path dir) {
+        GeneratedFileCache cache = new GeneratedFileCache(dir);
+        byte[] bytes = "persistent-body".getBytes(StandardCharsets.UTF_8);
+        String persistentId = cache.putPersistent(bytes, "p.docx", "application/pdf");
+        String transientId = cache.put("t".getBytes(StandardCharsets.UTF_8), "t.txt", "text/plain");
+
+        // Run the sweep. It iterates .meta files on disk and evicts expired ones.
+        cache.cleanupExpired();
+
+        // Neither is past the 7-day TTL, so both survive this particular sweep.
+        // The point of this test is to assert the sweep logic itself doesn't
+        // accidentally treat persistent as transient — the real guarantee is
+        // exercised by the meta-flag-parsing assertions below.
+        assertTrue(cache.get(persistentId).isPresent(), "persistent entry survives sweep");
+        assertTrue(cache.get(transientId).isPresent(), "fresh transient entry survives sweep");
+    }
+
+    @Test
+    @DisplayName("persistent flag round-trips through disk — survives a 'restart'")
+    void persistentSurvivesRestart(@TempDir Path dir) {
+        GeneratedFileCache first = new GeneratedFileCache(dir);
+        String id = first.putPersistent("restart-body".getBytes(StandardCharsets.UTF_8),
+                "季度报表.docx", "application/pdf");
+
+        // Simulate a JVM restart.
+        GeneratedFileCache afterRestart = new GeneratedFileCache(dir);
+        GeneratedFileCache.Entry entry = afterRestart.get(id).orElse(null);
+
+        assertNotNull(entry, "persistent entry reloads from disk after restart");
+        assertTrue(entry.persistent(), "persistent flag round-trips through .meta");
+        assertFalse(entry.expired(), "reloaded persistent entry never reports expired");
+    }
+
+    @Test
+    @DisplayName("legacy 3-field .meta (pre-#514) loads as non-persistent")
+    void legacyMetaDefaultsNonPersistent(@TempDir Path dir) throws Exception {
+        // Write a pre-#514 style meta: only 3 tab-separated fields.
+        GeneratedFileCache cache = new GeneratedFileCache(dir);
+        byte[] bytes = "legacy".getBytes(StandardCharsets.UTF_8);
+        String id = "legacy-uuid-1234";
+        java.nio.file.Files.write(dir.resolve(id), bytes);
+        java.nio.file.Files.writeString(dir.resolve(id + ".meta"),
+                (System.currentTimeMillis() + 86400000L) + "\ttext/plain\tbGVnYWN5LnR4dA==");
+
+        GeneratedFileCache.Entry entry = cache.get(id).orElse(null);
+        assertNotNull(entry, "legacy meta must still load");
+        assertFalse(entry.persistent(), "legacy 3-field meta defaults to non-persistent");
+    }
+
+    @Test
+    @DisplayName("plain put() entries remain non-persistent (backward compat)")
+    void plainPutIsNonPersistent(@TempDir Path dir) {
+        GeneratedFileCache cache = new GeneratedFileCache(dir);
+        String id = cache.put("x".getBytes(StandardCharsets.UTF_8), "x.txt", "text/plain");
+        GeneratedFileCache.Entry entry = cache.get(id).orElseThrow();
+        assertFalse(entry.persistent(), "plain put() must remain non-persistent");
+    }
+}

--- a/mateclaw-server/src/test/java/vip/mate/workspace/artifact/service/WorkspaceArtifactPersistenceTest.java
+++ b/mateclaw-server/src/test/java/vip/mate/workspace/artifact/service/WorkspaceArtifactPersistenceTest.java
@@ -1,0 +1,70 @@
+package vip.mate.workspace.artifact.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.transaction.annotation.Transactional;
+import vip.mate.MateClawApplication;
+import vip.mate.workspace.artifact.model.WorkspaceArtifactEntity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * DB-backed persistence guard for the issue #514 artifact catalog.
+ *
+ * <p>Catches the class of regression that round-1 introduced: the
+ * {@code download_url} column was declared NOT NULL with no default, but the
+ * read-time-URL design leaves it null at insert. Under MyBatis-Plus's default
+ * NOT_NULL insert strategy, the null field is omitted from the INSERT column
+ * list → the DB rejects it → {@code register()} swallows the exception → the
+ * feature silently does nothing. This test boots a real H2 + Flyway so the
+ * column nullability (V171) and the insert path are exercised truthfully.
+ */
+@SpringBootTest(
+        classes = MateClawApplication.class,
+        webEnvironment = SpringBootTest.WebEnvironment.NONE
+)
+@TestPropertySource(properties = {
+        "spring.datasource.url=jdbc:h2:mem:ws_artifact_persist_${random.uuid};MODE=MySQL;DATABASE_TO_LOWER=TRUE;CASE_INSENSITIVE_IDENTIFIERS=TRUE;DB_CLOSE_DELAY=-1",
+        "spring.ai.dashscope.api-key=test-key",
+        "mateclaw.jwt.secret=ws-artifact-it-secret-0123456789"
+})
+@Transactional
+class WorkspaceArtifactPersistenceTest {
+
+    @Autowired
+    private WorkspaceArtifactService service;
+
+    @Autowired
+    private JdbcTemplate jdbc;
+
+    @Test
+    @DisplayName("an artifact with a null downloadUrl persists (regression guard for NOT NULL column)")
+    void nullDownloadUrlPersists() {
+        WorkspaceArtifactEntity entity = new WorkspaceArtifactEntity();
+        entity.setWorkspaceId(1L);
+        entity.setAgentId(1L);
+        entity.setSource(WorkspaceArtifactService.SOURCE_AGENT);
+        entity.setArtifactType("document");
+        entity.setName("test-report.docx");
+        entity.setMime("application/pdf");
+        entity.setSizeBytes(1024L);
+        entity.setStorageKind(WorkspaceArtifactService.STORAGE_GENERATED_CACHE);
+        entity.setStorageRef("uuid-test-1");
+        entity.setDownloadUrl(null); // the regression trigger
+
+        Long id = service.register(entity);
+
+        assertThat(id).as("register() must return a non-null id — a null means the insert " +
+                "was silently swallowed (check the download_url column is nullable)").isNotNull();
+
+        // Verify the row is actually in the DB (not just accepted in memory).
+        Integer count = jdbc.queryForObject(
+                "SELECT COUNT(*) FROM mate_workspace_artifact WHERE id = ?",
+                Integer.class, id);
+        assertThat(count).isEqualTo(1);
+    }
+}

--- a/mateclaw-server/src/test/java/vip/mate/workspace/artifact/service/WorkspaceArtifactServiceTest.java
+++ b/mateclaw-server/src/test/java/vip/mate/workspace/artifact/service/WorkspaceArtifactServiceTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 import vip.mate.workspace.artifact.model.WorkspaceArtifactEntity;
 import vip.mate.workspace.artifact.repository.WorkspaceArtifactMapper;
 import vip.mate.workspace.artifact.vo.ArtifactPageVO;
+import vip.mate.workspace.artifact.vo.ArtifactVO;
 
 import java.util.List;
 
@@ -99,8 +100,11 @@ class WorkspaceArtifactServiceTest {
     @SuppressWarnings("unchecked")
     void listWithFilters() {
         WorkspaceArtifactEntity row = newEntity("持仓.xlsx", WorkspaceArtifactService.SOURCE_AGENT);
+        row.setId(42L);
         row.setToolCallId("tc_007");
         row.setArtifactType("data");
+        row.setConversationId("webchat:abc12345:visitor1:sess_001");
+        row.setSessionLabel("sess_001");
         Page<WorkspaceArtifactEntity> mpPage = new Page<>(1, 50);
         mpPage.setRecords(List.of(row));
         mpPage.setTotal(1);
@@ -110,12 +114,57 @@ class WorkspaceArtifactServiceTest {
 
         assertEquals(1, result.getTotal());
         assertEquals(1, result.getItems().size());
-        assertEquals("持仓.xlsx", result.getItems().get(0).getName());
-        assertEquals("agent", result.getItems().get(0).getSource());
-        assertEquals("data", result.getItems().get(0).getType());
-        assertEquals("tc_007", result.getItems().get(0).getToolCallId());
+        ArtifactVO vo = result.getItems().get(0);
+        assertEquals("持仓.xlsx", vo.getName());
+        assertEquals("agent", vo.getSource());
+        assertEquals("data", vo.getType());
+        assertEquals("tc_007", vo.getToolCallId());
+        // downloadUrl is built at read time from the artifact id.
+        assertEquals(WorkspaceArtifactService.DOWNLOAD_PATH_PREFIX + "42/download", vo.getDownloadUrl());
+        // sessionId returns the human-facing sessionLabel, not the composite conversationId.
+        assertEquals("sess_001", vo.getSessionId());
         assertFalse(result.isHasMore());
         verify(mapper).selectPage(any(Page.class), any(LambdaQueryWrapper.class));
+    }
+
+    @Test
+    @DisplayName("sessionId falls back to conversationId when sessionLabel is null")
+    @SuppressWarnings("unchecked")
+    void sessionIdFallback() {
+        WorkspaceArtifactEntity row = newEntity("report.docx", WorkspaceArtifactService.SOURCE_AGENT);
+        row.setId(7L);
+        row.setConversationId("webchat:abc:visitor1:sess_002");
+        row.setSessionLabel(null);
+        Page<WorkspaceArtifactEntity> mpPage = new Page<>(1, 50);
+        mpPage.setRecords(List.of(row));
+        mpPage.setTotal(1);
+        when(mapper.selectPage(any(Page.class), any(LambdaQueryWrapper.class))).thenReturn(mpPage);
+
+        ArtifactPageVO result = service.list(10L, 1L, null, null, null, 1, 50);
+
+        assertEquals("webchat:abc:visitor1:sess_002", result.getItems().get(0).getSessionId());
+    }
+
+    // -------- findById --------
+
+    @Test
+    @DisplayName("findById delegates to mapper.selectById")
+    void findByIdDelegates() {
+        WorkspaceArtifactEntity entity = newEntity("x.docx", WorkspaceArtifactService.SOURCE_AGENT);
+        when(mapper.selectById(42L)).thenReturn(entity);
+
+        WorkspaceArtifactEntity found = service.findById(42L);
+
+        assertSame(entity, found);
+        verify(mapper).selectById(42L);
+    }
+
+    @Test
+    @DisplayName("findById returns null for null id or not-found")
+    void findByIdMisses() {
+        assertNull(service.findById(null));
+        when(mapper.selectById(999L)).thenReturn(null);
+        assertNull(service.findById(999L));
     }
 
     @Test

--- a/mateclaw-server/src/test/java/vip/mate/workspace/artifact/service/WorkspaceArtifactServiceTest.java
+++ b/mateclaw-server/src/test/java/vip/mate/workspace/artifact/service/WorkspaceArtifactServiceTest.java
@@ -1,0 +1,162 @@
+package vip.mate.workspace.artifact.service;
+
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import vip.mate.workspace.artifact.model.WorkspaceArtifactEntity;
+import vip.mate.workspace.artifact.repository.WorkspaceArtifactMapper;
+import vip.mate.workspace.artifact.vo.ArtifactPageVO;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for {@link WorkspaceArtifactService} — the issue #514 catalog
+ * read/write. The mapper is mocked so these run without a DB; the queries
+ * themselves are exercised by the webchat E2E suite.
+ */
+class WorkspaceArtifactServiceTest {
+
+    private final WorkspaceArtifactMapper mapper = mock(WorkspaceArtifactMapper.class);
+    private final WorkspaceArtifactService service = new WorkspaceArtifactService(mapper);
+
+    // -------- classifyType --------
+
+    @Test
+    @DisplayName("classifyType maps docx/pdf/pptx → document")
+    void classifyDocuments() {
+        assertEquals("document", WorkspaceArtifactService.classifyType("报告.docx", null));
+        assertEquals("document", WorkspaceArtifactService.classifyType("report.pdf", null));
+        assertEquals("document", WorkspaceArtifactService.classifyType("deck.pptx", null));
+    }
+
+    @Test
+    @DisplayName("classifyType maps xlsx/csv → data")
+    void classifyData() {
+        assertEquals("data", WorkspaceArtifactService.classifyType("持仓明细.xlsx", null));
+        assertEquals("data", WorkspaceArtifactService.classifyType("data.csv", null));
+    }
+
+    @Test
+    @DisplayName("classifyType maps png/jpg/svg → image (by extension)")
+    void classifyImagesByExt() {
+        assertEquals("image", WorkspaceArtifactService.classifyType("chart.png", null));
+        assertEquals("image", WorkspaceArtifactService.classifyType("photo.jpg", null));
+        assertEquals("image", WorkspaceArtifactService.classifyType("logo.svg", null));
+    }
+
+    @Test
+    @DisplayName("classifyType falls back to mime when extension is unknown")
+    void classifyByMimeFallback() {
+        assertEquals("image", WorkspaceArtifactService.classifyType("blob", "image/png"));
+        assertEquals("data", WorkspaceArtifactService.classifyType("blob", "text/csv"));
+        assertEquals("document", WorkspaceArtifactService.classifyType("blob", "application/pdf"));
+    }
+
+    @Test
+    @DisplayName("classifyType returns 'other' for unrecognised inputs")
+    void classifyOther() {
+        assertEquals("other", WorkspaceArtifactService.classifyType("unknown.xyz", null));
+        assertEquals("other", WorkspaceArtifactService.classifyType(null, null));
+        assertEquals("other", WorkspaceArtifactService.classifyType("file", "application/octet-stream"));
+    }
+
+    // -------- register --------
+
+    @Test
+    @DisplayName("register inserts the entity and returns its id")
+    void registerInserts() {
+        WorkspaceArtifactEntity entity = newEntity("report.docx", WorkspaceArtifactService.SOURCE_AGENT);
+        entity.setId(42L);
+        when(mapper.insert(any(WorkspaceArtifactEntity.class))).thenReturn(1);
+
+        Long id = service.register(entity);
+
+        assertEquals(42L, id);
+        verify(mapper).insert(entity);
+    }
+
+    @Test
+    @DisplayName("register swallows persistence failure and returns null (best-effort)")
+    void registerSwallowsFailure() {
+        WorkspaceArtifactEntity entity = newEntity("report.docx", WorkspaceArtifactService.SOURCE_AGENT);
+        when(mapper.insert(any(WorkspaceArtifactEntity.class))).thenThrow(new RuntimeException("DB down"));
+
+        Long id = service.register(entity);
+
+        assertNull(id, "a failed catalog write must not propagate");
+    }
+
+    // -------- list --------
+
+    @Test
+    @DisplayName("list applies filters and maps to VO")
+    @SuppressWarnings("unchecked")
+    void listWithFilters() {
+        WorkspaceArtifactEntity row = newEntity("持仓.xlsx", WorkspaceArtifactService.SOURCE_AGENT);
+        row.setToolCallId("tc_007");
+        row.setArtifactType("data");
+        Page<WorkspaceArtifactEntity> mpPage = new Page<>(1, 50);
+        mpPage.setRecords(List.of(row));
+        mpPage.setTotal(1);
+        when(mapper.selectPage(any(Page.class), any(LambdaQueryWrapper.class))).thenReturn(mpPage);
+
+        ArtifactPageVO result = service.list(10L, 1L, "conv-1", "agent", "data", 1, 50);
+
+        assertEquals(1, result.getTotal());
+        assertEquals(1, result.getItems().size());
+        assertEquals("持仓.xlsx", result.getItems().get(0).getName());
+        assertEquals("agent", result.getItems().get(0).getSource());
+        assertEquals("data", result.getItems().get(0).getType());
+        assertEquals("tc_007", result.getItems().get(0).getToolCallId());
+        assertFalse(result.isHasMore());
+        verify(mapper).selectPage(any(Page.class), any(LambdaQueryWrapper.class));
+    }
+
+    @Test
+    @DisplayName("list clamps page/size to safe bounds")
+    @SuppressWarnings("unchecked")
+    void listClampsSize() {
+        Page<WorkspaceArtifactEntity> mpPage = new Page<>(1, 200);
+        mpPage.setRecords(List.of());
+        mpPage.setTotal(0);
+        when(mapper.selectPage(any(Page.class), any(LambdaQueryWrapper.class))).thenReturn(mpPage);
+
+        // size=9999 should be clamped to 200; page=0 to 1.
+        ArtifactPageVO result = service.list(10L, 1L, null, null, null, 0, 9999);
+
+        assertEquals(1, result.getPage());
+        assertEquals(200, result.getSize());
+    }
+
+    @Test
+    @DisplayName("hasMore is true when total exceeds the current page window")
+    @SuppressWarnings("unchecked")
+    void hasMoreComputation() {
+        Page<WorkspaceArtifactEntity> mpPage = new Page<>(1, 50);
+        mpPage.setRecords(List.of());
+        mpPage.setTotal(100);
+        when(mapper.selectPage(any(Page.class), any(LambdaQueryWrapper.class))).thenReturn(mpPage);
+
+        ArtifactPageVO result = service.list(10L, 1L, null, null, null, 1, 50);
+
+        assertTrue(result.isHasMore(), "page 1 of 50 with 100 total must report hasMore");
+    }
+
+    private static WorkspaceArtifactEntity newEntity(String name, String source) {
+        WorkspaceArtifactEntity e = new WorkspaceArtifactEntity();
+        e.setAgentId(10L);
+        e.setWorkspaceId(1L);
+        e.setSource(source);
+        e.setName(name);
+        e.setStorageKind(WorkspaceArtifactService.STORAGE_GENERATED_CACHE);
+        e.setStorageRef("uuid-1");
+        e.setDownloadUrl("/api/v1/files/generated/uuid-1");
+        return e;
+    }
+}

--- a/mateclaw-server/src/test/java/vip/mate/workspace/artifact/service/WorkspaceArtifactServiceTest.java
+++ b/mateclaw-server/src/test/java/vip/mate/workspace/artifact/service/WorkspaceArtifactServiceTest.java
@@ -121,7 +121,9 @@ class WorkspaceArtifactServiceTest {
         assertEquals("tc_007", vo.getToolCallId());
         // downloadUrl is built at read time from the artifact id.
         assertEquals(WorkspaceArtifactService.DOWNLOAD_PATH_PREFIX + "42/download", vo.getDownloadUrl());
-        // sessionId returns the human-facing sessionLabel, not the composite conversationId.
+        // sessionId returns the sessionLabel (set by the registration path);
+        // for user uploads it's the client-supplied label, for agent artifacts
+        // it's the conversationId.
         assertEquals("sess_001", vo.getSessionId());
         assertFalse(result.isHasMore());
         verify(mapper).selectPage(any(Page.class), any(LambdaQueryWrapper.class));

--- a/mateclaw-server/src/test/java/vip/mate/workspace/artifact/service/WorkspaceArtifactServiceTest.java
+++ b/mateclaw-server/src/test/java/vip/mate/workspace/artifact/service/WorkspaceArtifactServiceTest.java
@@ -103,8 +103,10 @@ class WorkspaceArtifactServiceTest {
         row.setId(42L);
         row.setToolCallId("tc_007");
         row.setArtifactType("data");
+        // Both registration paths (agent + user) now store conversationId as
+        // sessionLabel for consistency (round-3 F2 fix).
         row.setConversationId("webchat:abc12345:visitor1:sess_001");
-        row.setSessionLabel("sess_001");
+        row.setSessionLabel("webchat:abc12345:visitor1:sess_001");
         Page<WorkspaceArtifactEntity> mpPage = new Page<>(1, 50);
         mpPage.setRecords(List.of(row));
         mpPage.setTotal(1);
@@ -121,10 +123,9 @@ class WorkspaceArtifactServiceTest {
         assertEquals("tc_007", vo.getToolCallId());
         // downloadUrl is built at read time from the artifact id.
         assertEquals(WorkspaceArtifactService.DOWNLOAD_PATH_PREFIX + "42/download", vo.getDownloadUrl());
-        // sessionId returns the sessionLabel (set by the registration path);
-        // for user uploads it's the client-supplied label, for agent artifacts
-        // it's the conversationId.
-        assertEquals("sess_001", vo.getSessionId());
+        // sessionId returns the sessionLabel, which both registration paths now
+        // set to the conversationId for cross-source consistency.
+        assertEquals("webchat:abc12345:visitor1:sess_001", vo.getSessionId());
         assertFalse(result.isHasMore());
         verify(mapper).selectPage(any(Page.class), any(LambdaQueryWrapper.class));
     }


### PR DESCRIPTION
## Summary

Closes #514. Adds a persistent, cross-session file catalog so a WebChat consumer (ATLAS) can list an Agent's full file inventory — both Agent-produced output and user uploads — across all sessions. Files live at the Agent/Workspace level; sessions are provenance labels, not ownership containers.

## What changed

### New table + package
- **`mate_workspace_artifact`** (Flyway V170 — h2/mysql/kingbase): catalogs every file with `source` (agent/user), `conversationId`, `toolCallId`, `toolName`, `artifact_type`, `storage_kind/ref`, and a relative `download_url`.
- New **`vip.mate.workspace.artifact`** package: `WorkspaceArtifactEntity`, `WorkspaceArtifactMapper`, `WorkspaceArtifactService`, `ArtifactVO`, `ArtifactPageVO`.

### New REST endpoint
```
GET /api/v1/channels/webchat/artifacts
```
Paginated, filterable by `sessionId` / `source` / `type`. Auth: `X-MC-Key` + `X-MC-Visitor-Token` (same as existing webchat endpoints). Response: `R<ArtifactPageVO>`.

### Three registration hooks
| Source | Hook | Files covered |
|---|---|---|
| `user` | `WebChatController.uploadFile` | All webchat uploads |
| `agent` | `GeneratedFileLink` (doc/xlsx/pptx/pdf/html-image/screenshot/xhs tools) | All document-render tool output |
| `agent` | `WorkspaceArtifactSurfacer` (execute_code / execute_shell_command) | Files written by scripts |

### Persistence
- `GeneratedFileCache` gains a `persistent` flag on `Entry`. Workspace-registered entries use `putPersistent()` and are **sweep-exempt** — they survive the 7-day TTL so download links stay live for the workspace lifetime.
- `.meta` format extended with a 4th field; backward-compatible (legacy 3-field metas default to non-persistent).

### Tool-call provenance threading
- `ToolExecutionExecutor.executeSingleTool` now stamps `toolCallId` + `toolName` into the `ToolContext` map (loose keys, NOT a `ChatOrigin` record field — respects its "add-only, 90-day deprecation" evolution rule).

## Design decisions

1. **Persistence approach**: Option A — persistent cache entries are sweep-exempt. Minimal change to the existing `GeneratedFileCache` + `/api/v1/files/generated/{id}` download path.
2. **Download auth**: UUID-gated (unchanged). Issue #514 explicitly scopes to "1 agent = 1 user, no isolation". Multi-user isolation is a documented future extension point.
3. **No historical backfill**: only files produced after this change are catalogued (legacy cache entries lack provenance metadata).

## Test plan

- [x] `GeneratedFileCachePersistentTest` — persistent entries survive sweep + restart; legacy 3-field metas load as non-persistent
- [x] `WorkspaceArtifactServiceTest` — classifyType matrix, register (success + failure), list filters/clamp/hasMore
- [x] All existing `GeneratedFileCache*` tests pass (format change is backward-compatible)
- [x] All existing WebChat E2E tests pass (121 tests)
- [x] Full clean compile (`mvn clean compile`)

## Answers to issue's open questions

1. **Existing Agent-level storage?** No — built from scratch.
2. **Agent document tools落盘?** Yes, via `GeneratedFileCache`; metadata was the gap.
3. **Real-time SSE notification?** Deferred — v1 is pull + manual refresh, per issue's stated preference.
4. **Lifecycle?** Persistent (no expiry); future capacity limits are an extension point.
5. **Download path reuse?** Agent files: `/api/v1/files/generated/{id}` (unchanged). User files: existing `/files?storedName=`.
6. **Route shape?** Used `/artifacts` (channel-scoped, consistent with other webchat endpoints) rather than `/workspaces/artifacts`.