### PR TITLE
fix(desktop): resolve http/https union type errors in electron main

### DIFF
--- a/mateclaw-desktop/electron/main/index.ts
+++ b/mateclaw-desktop/electron/main/index.ts
@@ -300,7 +300,10 @@ function pollBackendReady(): void {
     const isHttps = BACKEND_URL.startsWith('https:')
     const client = isHttps ? https : http
     const reqOpts = isHttps ? { agent: insecureAgent } : {}
-    const req = client.get(`${BACKEND_URL}/`, reqOpts, (res) => {
+    // Cast to the http module type so TS treats .get() as callable — https
+    // exposes the same surface, but the union `typeof https | typeof http`
+    // is not directly callable.
+    const req = (client as typeof http).get(`${BACKEND_URL}/`, reqOpts, (res) => {
       if (resolved) return
       resolved = true
 
@@ -430,7 +433,7 @@ function probeServer(
     const isHttps = normalized.startsWith('https:')
     const client = isHttps ? https : http
     const reqOpts = isHttps ? { agent: insecureAgent } : {}
-    const req = client.get(`${normalized}/`, reqOpts, (res) => {
+    const req = (client as typeof http).get(`${normalized}/`, reqOpts, (res) => {
       res.resume()
       const status = res.statusCode ?? 0
       // Any non-5xx response means the server is reachable and serving.


### PR DESCRIPTION
## What

Fixes #563 — 5 `vue-tsc` type errors in `mateclaw-desktop/electron/main/index.ts` that block `npm run build`.

## Root cause

The backend health-check helper infers a union type:
```ts
const client = isHttps ? https : http   // typeof https | typeof http
const req = client.get(...)              // TS2349: not callable on a union
```
TypeScript won't call `.get()` on the union (overloads differ), cascading into implicit-any on the `res`/`err` callbacks.

## Fix

Cast `client` to `typeof http` at the call site — `https` exposes the same callable surface, so runtime is unchanged. Applied to both health-check occurrences (lines ~303 and ~436).

## Verification

```
cd mateclaw-desktop && npx vue-tsc --noEmit
```
Before: 5 errors. After: **0 errors**.

Based on `dev` (`e294b325`), no other files touched.