### PR TITLE
feat(agent): global read-only preset Agents for every workspace (#567)

### DIFF
--- a/mateclaw-server/src/main/java/vip/mate/agent/AgentService.java
+++ b/mateclaw-server/src/main/java/vip/mate/agent/AgentService.java
@@ -24,6 +24,7 @@ import vip.mate.memory.service.MemoryRecallTracker;
 import vip.mate.team.event.TeamChangedEvent;
 import vip.mate.workspace.conversation.model.ConversationEntity;
 import vip.mate.workspace.conversation.repository.ConversationMapper;
+import vip.mate.workspace.core.service.WorkspaceService;
 
 import java.util.List;
 import java.time.Duration;
@@ -102,8 +103,13 @@ public class AgentService {
      *                disabled rows visible for re-enabling.
      */
     public List<AgentEntity> listAgentsByWorkspace(Long workspaceId, Boolean enabled) {
+        // 全局共享预置 Agent（workspace_id = 0）对本工作区只读可见，故与本工作区
+        // Agent 一并返回。用 .and(...) 嵌套包裹 OR，确保后续 enabled 条件以 AND
+        // 作用于整个 (workspace_id = wsId OR workspace_id = 0) 分组，而非仅后者。
         LambdaQueryWrapper<AgentEntity> q = new LambdaQueryWrapper<AgentEntity>()
-                .eq(AgentEntity::getWorkspaceId, workspaceId);
+                .and(w -> w.eq(AgentEntity::getWorkspaceId, workspaceId)
+                        .or()
+                        .eq(AgentEntity::getWorkspaceId, WorkspaceService.GLOBAL_WORKSPACE_ID));
         if (enabled != null) {
             q.eq(AgentEntity::getEnabled, enabled);
         }
@@ -119,6 +125,13 @@ public class AgentService {
     }
 
     public AgentEntity createAgent(AgentEntity agent) {
+        // workspace_id = 0 保留给全局共享预置（系统维护），用户路径不得创建——
+        // 堵住 AgentController.create 直接取 X-Workspace-Id 头可能传入 0 的漏洞。
+        if (agent.getWorkspaceId() != null
+                && agent.getWorkspaceId() == WorkspaceService.GLOBAL_WORKSPACE_ID) {
+            throw new MateClawException("err.agent.global_preset_readonly", 403,
+                    "全局预置 Agent 由系统维护，不可创建");
+        }
         agent.setEnabled(true);
         if (agent.getAgentType() == null) {
             agent.setAgentType("react");
@@ -134,6 +147,7 @@ public class AgentService {
         // intent rather than every metadata edit. Reading the prior row
         // is cheap and gives us a clean diff source.
         AgentEntity prior = agentMapper.selectById(agent.getId());
+        requireMutable(prior);
         // Only re-validate uniqueness when the name actually changes —
         // a pure metadata edit (icon, prompt, ...) shouldn't pay the
         // SELECT cost or risk a false positive against the row itself.
@@ -191,8 +205,24 @@ public class AgentService {
         }
     }
 
+    /**
+     * 拒绝任何用户态写路径作用于全局共享预置 Agent（{@code workspace_id = 0}）。
+     *
+     * <p>预置由产品统一维护（单一事实源），对所有工作区只读可见；若允许用户修改
+     * 或删除，会污染每个工作区看到的版本。镜像 {@link #requireUniqueName} 的
+     * {@code requireX} 约定，在 mutator 顶部调用。{@code agent == null} 时无可保护
+     * 的记录，直接放行（后续操作至多是 no-op）。
+     */
+    private void requireMutable(AgentEntity agent) {
+        if (agent != null && agent.isGlobalPreset()) {
+            throw new MateClawException("err.agent.global_preset_readonly", 403,
+                    "全局预置 Agent 由系统维护，不可修改或删除: " + agent.getName());
+        }
+    }
+
     public void deleteAgent(Long id) {
         AgentEntity prior = agentMapper.selectById(id);
+        requireMutable(prior);
         agentMapper.deleteById(id);
         agentInstances.remove(id);
         if (prior != null) publishLifecycle(prior, "terminated");

--- a/mateclaw-server/src/main/java/vip/mate/agent/binding/service/AgentBindingService.java
+++ b/mateclaw-server/src/main/java/vip/mate/agent/binding/service/AgentBindingService.java
@@ -173,6 +173,7 @@ public class AgentBindingService implements AgentBindingResolver {
     }
 
     public AgentSkillBinding bindSkill(Long agentId, Long skillId) {
+        requireNotGlobalPreset(agentId);
         requireSameWorkspace(agentId, skillId);
         // Adding any skill binding is a concrete commitment — the operator
         // wants this skill on the agent, which contradicts an opt-out flag.
@@ -197,6 +198,7 @@ public class AgentBindingService implements AgentBindingResolver {
     }
 
     public void unbindSkill(Long agentId, Long skillId) {
+        requireNotGlobalPreset(agentId);
         skillBindingMapper.delete(
                 new LambdaQueryWrapper<AgentSkillBinding>()
                         .eq(AgentSkillBinding::getAgentId, agentId)
@@ -214,6 +216,7 @@ public class AgentBindingService implements AgentBindingResolver {
      * touch the flag — the caller (UI toggle) owns that bit.
      */
     public void setSkillBindings(Long agentId, List<Long> skillIds) {
+        requireNotGlobalPreset(agentId);
         // Validate every incoming skill BEFORE touching the binding rows;
         // a half-applied save (old bindings dropped, new set rejected
         // mid-loop) would leave the agent silently un-bound from skills it
@@ -417,6 +420,25 @@ public class AgentBindingService implements AgentBindingResolver {
                     "Skill " + skillId + " (workspace=" + skillWs
                             + ") cannot be bound to Agent " + agentId
                             + " (workspace=" + agentWs + ")");
+        }
+    }
+
+    /**
+     * 拒绝对全局共享预置 Agent（{@code workspace_id = 0}）的任何绑定变更。
+     *
+     * <p>预置的工具/技能/KB 绑定由产品统一维护（单一事实源），对所有工作区只读；
+     * 允许用户改动会污染每个工作区看到的预置能力。镜像 {@link #requireSameWorkspace}
+     * 的 {@code requireX} 约定，在每个绑定 mutator 顶部调用。注意：系统级清理
+     * （技能/MCP 删除监听器）不走此守卫——悬空绑定清理对全局预置仍应执行。
+     */
+    private void requireNotGlobalPreset(Long agentId) {
+        if (agentId == null) {
+            return;
+        }
+        AgentEntity agent = agentMapper.selectById(agentId);
+        if (agent != null && agent.isGlobalPreset()) {
+            throw new MateClawException("err.agent.global_preset_readonly", 403,
+                    "全局预置 Agent 由系统维护，不可修改或删除: " + agent.getName());
         }
     }
 
@@ -798,6 +820,7 @@ public class AgentBindingService implements AgentBindingResolver {
     }
 
     public AgentToolBinding bindTool(Long agentId, String toolName) {
+        requireNotGlobalPreset(agentId);
         // Mirror of bindSkill: writing any tool row clears the opt-out flag
         // so the binding state cannot contradict the agent-level toggle.
         clearToolsDisabledFlag(agentId);
@@ -819,6 +842,7 @@ public class AgentBindingService implements AgentBindingResolver {
     }
 
     public void unbindTool(Long agentId, String toolName) {
+        requireNotGlobalPreset(agentId);
         toolBindingMapper.delete(
                 new LambdaQueryWrapper<AgentToolBinding>()
                         .eq(AgentToolBinding::getAgentId, agentId)
@@ -845,6 +869,7 @@ public class AgentBindingService implements AgentBindingResolver {
      * </ul>
      */
     public void setToolBindings(Long agentId, List<String> toolNames) {
+        requireNotGlobalPreset(agentId);
         validateNewToolBindings(agentId, toolNames);
 
         // Side effect parallel to setSkillBindings: a non-empty save is an
@@ -952,6 +977,7 @@ public class AgentBindingService implements AgentBindingResolver {
      * preferred-model chain. Empty / null list clears all preferences.
      */
     public void setProviderModelPreferences(Long agentId, List<ProviderModelRef> refs) {
+        requireNotGlobalPreset(agentId);
         providerPreferenceMapper.delete(
                 new LambdaQueryWrapper<AgentProviderPreference>()
                         .eq(AgentProviderPreference::getAgentId, agentId));
@@ -1022,6 +1048,7 @@ public class AgentBindingService implements AgentBindingResolver {
      * from another tenancy is refused (403).
      */
     public void setKbBindings(Long agentId, List<Long> kbIds) {
+        requireNotGlobalPreset(agentId);
         // De-dup defensively: the unique index is (agent_id, kb_id, deleted),
         // so two identical ids in the incoming list would collide on insert.
         Set<Long> distinct = new LinkedHashSet<>();

--- a/mateclaw-server/src/main/java/vip/mate/agent/model/AgentEntity.java
+++ b/mateclaw-server/src/main/java/vip/mate/agent/model/AgentEntity.java
@@ -154,4 +154,15 @@ public class AgentEntity {
     private LocalDateTime updateTime;
 
     private Integer deleted;
+
+    /**
+     * 是否为全局共享预置 Agent（{@code workspace_id == 0}）。
+     *
+     * <p>全局预置由产品统一维护、对所有工作区只读可见，故任何用户态写路径
+     * （更新/删除/改绑定）都应拒绝作用于这类记录。常量定义见
+     * {@code WorkspaceService.GLOBAL_WORKSPACE_ID}；此处用字面量避免实体反向依赖服务层。
+     */
+    public boolean isGlobalPreset() {
+        return workspaceId != null && workspaceId == 0L;
+    }
 }

--- a/mateclaw-server/src/main/java/vip/mate/tool/builtin/DelegateAgentTool.java
+++ b/mateclaw-server/src/main/java/vip/mate/tool/builtin/DelegateAgentTool.java
@@ -24,6 +24,7 @@ import vip.mate.channel.web.ChatStreamTracker;
 import vip.mate.task.AsyncTaskService;
 import vip.mate.task.model.AsyncTaskEntity;
 import vip.mate.workspace.conversation.ConversationService;
+import vip.mate.workspace.core.service.WorkspaceService;
 
 import java.time.Duration;
 import java.util.*;
@@ -240,7 +241,7 @@ public class DelegateAgentTool {
             return "[错误] 委派层级已达上限（" + MAX_DELEGATION_DEPTH + " 层），请直接处理任务。";
         }
 
-        AgentEntity target = findAgent(agentName);
+        AgentEntity target = findAgent(agentName, callerWorkspaceId(ctx));
         if (target == null) {
             return "[错误] 未找到名为「" + agentName + "」的已启用 Agent。" + availableAgentsHint();
         }
@@ -498,7 +499,7 @@ public class DelegateAgentTool {
                 continue;
             }
 
-            AgentEntity agent = findAgent(agentName);
+            AgentEntity agent = findAgent(agentName, callerWorkspaceId(ctx));
             if (agent == null) {
                 errors.add("[任务 " + (i + 1) + "] 未找到 Agent「" + agentName + "」");
                 continue;
@@ -806,7 +807,7 @@ public class DelegateAgentTool {
             return errorJson("Delegation depth exceeded (max " + MAX_DELEGATION_DEPTH + ")");
         }
 
-        AgentEntity target = findAgent(agentName);
+        AgentEntity target = findAgent(agentName, callerWorkspaceId(ctx));
         if (target == null) {
             return errorJson("Agent not found: " + agentName);
         }
@@ -1261,10 +1262,27 @@ public class DelegateAgentTool {
         return sb.toString();
     }
 
-    private AgentEntity findAgent(String name) {
-        return agentMapper.selectOne(new LambdaQueryWrapper<AgentEntity>()
+    private AgentEntity findAgent(String name, Long workspaceId) {
+        LambdaQueryWrapper<AgentEntity> q = new LambdaQueryWrapper<AgentEntity>()
                 .eq(AgentEntity::getName, name.trim())
-                .eq(AgentEntity::getEnabled, true));
+                .eq(AgentEntity::getEnabled, true);
+        if (workspaceId != null) {
+            // 限定为「调用方工作区或全局预置」，避免命中其他工作区的同名 Agent。
+            q.and(w -> w.eq(AgentEntity::getWorkspaceId, workspaceId)
+                    .or()
+                    .eq(AgentEntity::getWorkspaceId, WorkspaceService.GLOBAL_WORKSPACE_ID));
+        }
+        // 本工作区 Agent 优先于全局预置（workspace_id=0）：取排序后首条而非 selectOne，
+        // 避免「全局预置 + 本地同名 Agent」并存时多结果抛 TooManyResultsException。
+        q.orderByDesc(AgentEntity::getWorkspaceId);
+        List<AgentEntity> matches = agentMapper.selectList(q);
+        return matches.isEmpty() ? null : matches.get(0);
+    }
+
+    /** 委派调用方的工作区 ID（无上下文时为 null，退回全局按名匹配）。 */
+    private Long callerWorkspaceId(ToolContext ctx) {
+        ChatOrigin origin = ChatOrigin.from(ctx);
+        return origin != null ? origin.workspaceId() : null;
     }
 
     /**

--- a/mateclaw-server/src/main/java/vip/mate/workspace/core/service/WorkspaceService.java
+++ b/mateclaw-server/src/main/java/vip/mate/workspace/core/service/WorkspaceService.java
@@ -46,6 +46,18 @@ public class WorkspaceService {
     /** 默认工作区 slug */
     public static final String DEFAULT_SLUG = "default";
 
+    /**
+     * 全局共享预置 Agent 的工作区 ID。
+     *
+     * <p>预置 Agent（General Assistant / Task Planner / 内容工作室等）本质是产品级
+     * 配置而非某个工作区的私有数据，故以保留值 {@code 0} 标记为"全局"。它们在
+     * {@code listAgentsByWorkspace} 中与本工作区 Agent 一并返回（只读），从而每个
+     * 新建工作区开箱即有预置 Agent、子代理委派可用，且产品只需维护一份（单一事实源）。
+     * 注意 {@code mate_agent.workspace_id} 为 {@code NOT NULL DEFAULT 1}，故用 {@code 0}
+     * 而非 {@code NULL} 表示全局，避免改动列约束。
+     */
+    public static final long GLOBAL_WORKSPACE_ID = 0L;
+
     /** 成员资格缓存：key = "workspaceId:userId"，value = role string（null 表示非成员） */
     private final Cache<String, String> membershipCache = Caffeine.newBuilder()
             .expireAfterWrite(Duration.ofSeconds(60))

--- a/mateclaw-server/src/main/resources/db/data-en.sql
+++ b/mateclaw-server/src/main/resources/db/data-en.sql
@@ -6,23 +6,23 @@ KEY (id)
 VALUES (1, 'admin', '$2a$10$7JB720yubVSZvUI0rEqK/.VqGOZTH.ulu33dHOiBE8ByOhJIrdAu2', 'MateClaw Admin', 'admin', TRUE, NOW(), NOW(), 0);
 
 -- Default digital employee: General Assistant (ReAct mode)
-MERGE INTO mate_agent (id, name, description, agent_type, system_prompt, model_name, max_iterations, enabled, icon, tags, create_time, update_time, deleted)
+MERGE INTO mate_agent (id, workspace_id, name, description, agent_type, system_prompt, model_name, max_iterations, enabled, icon, tags, create_time, update_time, deleted)
 KEY (id)
-VALUES (1000000001, 'General Assistant', 'All-purpose helper for day-to-day questions, data analysis, and tool calling', 'react',
+VALUES (1000000001, 0, 'General Assistant', 'All-purpose helper for day-to-day questions, data analysis, and tool calling', 'react',
         'You are MateClaw''s General Assistant. You can help users answer questions, analyze data, and call tools to get things done. Please respond professionally and in a friendly manner.',
         NULL, 100, TRUE, 'pi:robot-face-happy', 'default,assistant', NOW(), NOW(), 0);
 
 -- Default digital employee: Task Planner (Plan-Execute mode)
-MERGE INTO mate_agent (id, name, description, agent_type, system_prompt, model_name, max_iterations, enabled, icon, tags, create_time, update_time, deleted)
+MERGE INTO mate_agent (id, workspace_id, name, description, agent_type, system_prompt, model_name, max_iterations, enabled, icon, tags, create_time, update_time, deleted)
 KEY (id)
-VALUES (1000000002, 'Task Planner', 'Breaks complex goals into executable steps and drives them forward to completion', 'plan_execute',
+VALUES (1000000002, 0, 'Task Planner', 'Breaks complex goals into executable steps and drives them forward to completion', 'plan_execute',
         'You are a professional Task Planner. You excel at breaking complex goals into executable steps and completing them systematically.',
         NULL, 100, TRUE, 'pi:clipboard-note', 'planning,task', NOW(), NOW(), 0);
 
 -- Default digital employee: Reasoning Analyst (explicit reasoning loops + tool calling)
-MERGE INTO mate_agent (id, name, description, agent_type, system_prompt, model_name, max_iterations, enabled, icon, tags, create_time, update_time, deleted)
+MERGE INTO mate_agent (id, workspace_id, name, description, agent_type, system_prompt, model_name, max_iterations, enabled, icon, tags, create_time, update_time, deleted)
 KEY (id)
-VALUES (1000000003, 'Reasoning Analyst', 'Thinks step by step with visible reasoning, ideal for problems that need thorough deliberation', 'react',
+VALUES (1000000003, 0, 'Reasoning Analyst', 'Thinks step by step with visible reasoning, ideal for problems that need thorough deliberation', 'react',
         'You are a Reasoning Analyst, an assistant that excels at deep reasoning. When facing a problem, first think through it step by step with a clear reasoning trace, then call tools or give the answer. Please respond professionally and in a friendly manner.',
         NULL, 100, TRUE, 'pi:cpu', 'react,reasoning,tools', NOW(), NOW(), 0);
 
@@ -1912,9 +1912,9 @@ VALUES (1000000630, 'WechatArticleExtractTool', 'WeChat Article Extract', 'Fetch
 MERGE INTO mate_tool (id, name, display_name, description, tool_type, bean_name, icon, enabled, builtin, create_time, update_time, deleted)
 KEY (id)
 VALUES (1000000631, 'GzhPublishTool', 'WeChat OA Publish', 'Publish a generated image-text article to a WeChat Official Account: action=draft uploads the cover and creates a 草稿箱 draft (recommended); action=publish free-publishes for verified accounts and requires explicit confirmation. Needs weixinoa.app_id/app_secret in system settings.', 'builtin', 'gzhPublishTool', '📤', TRUE, TRUE, NOW(), NOW(), 0);
-MERGE INTO mate_agent (id, name, description, agent_type, system_prompt, model_name, max_iterations, enabled, icon, tags, create_time, update_time, deleted)
+MERGE INTO mate_agent (id, workspace_id, name, description, agent_type, system_prompt, model_name, max_iterations, enabled, icon, tags, create_time, update_time, deleted)
 KEY (id)
-VALUES (1000000640, 'Content Studio', 'End-to-end 公众号 & 小红书 image-text creation: research, write, illustrate, de-AI, layout, and publish to draft.', 'react', 'You are MateClaw''s Content Studio — a specialist that creates WeChat Official Account (公众号) and Xiaohongshu (小红书) image-text posts end to end.
+VALUES (1000000640, 0, 'Content Studio', 'End-to-end 公众号 & 小红书 image-text creation: research, write, illustrate, de-AI, layout, and publish to draft.', 'react', 'You are MateClaw''s Content Studio — a specialist that creates WeChat Official Account (公众号) and Xiaohongshu (小红书) image-text posts end to end.
 
 Workflow (7 stages):
 1) Topic — use the topic_interests memory + web_search(freshness=week) to find angles.

--- a/mateclaw-server/src/main/resources/db/data-kingbase-en.sql
+++ b/mateclaw-server/src/main/resources/db/data-kingbase-en.sql
@@ -6,18 +6,18 @@ VALUES (1, 'admin', '$2a$10$7JB720yubVSZvUI0rEqK/.VqGOZTH.ulu33dHOiBE8ByOhJIrdAu
 ON CONFLICT (id) DO UPDATE SET username=EXCLUDED.username, password=EXCLUDED.password, nickname=EXCLUDED.nickname, role=EXCLUDED.role, enabled=EXCLUDED.enabled, update_time=EXCLUDED.update_time, deleted=EXCLUDED.deleted;
 
 -- Default digital employee: General Assistant (ReAct mode)
-INSERT INTO mate_agent (id, name, description, agent_type, system_prompt, model_name, max_iterations, enabled, icon, tags, create_time, update_time, deleted)
-VALUES (1000000001, 'General Assistant', 'All-purpose helper for day-to-day questions, data analysis, and tool calling', 'react', 'You are MateClaw''s General Assistant. You can help users answer questions, analyze data, and call tools to get things done. Please respond professionally and in a friendly manner.', NULL, 100, TRUE, 'pi:robot-face-happy', 'default,assistant', NOW(), NOW(), 0)
+INSERT INTO mate_agent (id, workspace_id, name, description, agent_type, system_prompt, model_name, max_iterations, enabled, icon, tags, create_time, update_time, deleted)
+VALUES (1000000001, 0, 'General Assistant', 'All-purpose helper for day-to-day questions, data analysis, and tool calling', 'react', 'You are MateClaw''s General Assistant. You can help users answer questions, analyze data, and call tools to get things done. Please respond professionally and in a friendly manner.', NULL, 100, TRUE, 'pi:robot-face-happy', 'default,assistant', NOW(), NOW(), 0)
 ON CONFLICT (id) DO UPDATE SET name=EXCLUDED.name, description=EXCLUDED.description, agent_type=EXCLUDED.agent_type, system_prompt=EXCLUDED.system_prompt, model_name=EXCLUDED.model_name, max_iterations=EXCLUDED.max_iterations, enabled=EXCLUDED.enabled, icon=EXCLUDED.icon, tags=EXCLUDED.tags, update_time=EXCLUDED.update_time, deleted=EXCLUDED.deleted;
 
 -- Default digital employee: Task Planner (Plan-Execute mode)
-INSERT INTO mate_agent (id, name, description, agent_type, system_prompt, model_name, max_iterations, enabled, icon, tags, create_time, update_time, deleted)
-VALUES (1000000002, 'Task Planner', 'Breaks complex goals into executable steps and drives them forward to completion', 'plan_execute', 'You are a professional Task Planner. You excel at breaking complex goals into executable steps and completing them systematically.', NULL, 100, TRUE, 'pi:clipboard-note', 'planning,task', NOW(), NOW(), 0)
+INSERT INTO mate_agent (id, workspace_id, name, description, agent_type, system_prompt, model_name, max_iterations, enabled, icon, tags, create_time, update_time, deleted)
+VALUES (1000000002, 0, 'Task Planner', 'Breaks complex goals into executable steps and drives them forward to completion', 'plan_execute', 'You are a professional Task Planner. You excel at breaking complex goals into executable steps and completing them systematically.', NULL, 100, TRUE, 'pi:clipboard-note', 'planning,task', NOW(), NOW(), 0)
 ON CONFLICT (id) DO UPDATE SET name=EXCLUDED.name, description=EXCLUDED.description, agent_type=EXCLUDED.agent_type, system_prompt=EXCLUDED.system_prompt, model_name=EXCLUDED.model_name, max_iterations=EXCLUDED.max_iterations, enabled=EXCLUDED.enabled, icon=EXCLUDED.icon, tags=EXCLUDED.tags, update_time=EXCLUDED.update_time, deleted=EXCLUDED.deleted;
 
 -- Default digital employee: Reasoning Analyst (explicit reasoning loops + tool calling)
-INSERT INTO mate_agent (id, name, description, agent_type, system_prompt, model_name, max_iterations, enabled, icon, tags, create_time, update_time, deleted)
-VALUES (1000000003, 'Reasoning Analyst', 'Thinks step by step with visible reasoning, ideal for problems that need thorough deliberation', 'react', 'You are a Reasoning Analyst, an assistant that excels at deep reasoning. When facing a problem, first think through it step by step with a clear reasoning trace, then call tools or give the answer. Please respond professionally and in a friendly manner.', NULL, 100, TRUE, 'pi:cpu', 'react,reasoning,tools', NOW(), NOW(), 0)
+INSERT INTO mate_agent (id, workspace_id, name, description, agent_type, system_prompt, model_name, max_iterations, enabled, icon, tags, create_time, update_time, deleted)
+VALUES (1000000003, 0, 'Reasoning Analyst', 'Thinks step by step with visible reasoning, ideal for problems that need thorough deliberation', 'react', 'You are a Reasoning Analyst, an assistant that excels at deep reasoning. When facing a problem, first think through it step by step with a clear reasoning trace, then call tools or give the answer. Please respond professionally and in a friendly manner.', NULL, 100, TRUE, 'pi:cpu', 'react,reasoning,tools', NOW(), NOW(), 0)
 ON CONFLICT (id) DO UPDATE SET name=EXCLUDED.name, description=EXCLUDED.description, agent_type=EXCLUDED.agent_type, system_prompt=EXCLUDED.system_prompt, model_name=EXCLUDED.model_name, max_iterations=EXCLUDED.max_iterations, enabled=EXCLUDED.enabled, icon=EXCLUDED.icon, tags=EXCLUDED.tags, update_time=EXCLUDED.update_time, deleted=EXCLUDED.deleted;
 
 -- ==================== Local Model Providers (displayed first) ====================
@@ -1837,8 +1837,8 @@ ON CONFLICT (id) DO UPDATE SET name=EXCLUDED.name, display_name=EXCLUDED.display
 INSERT INTO mate_tool (id, name, display_name, description, tool_type, bean_name, icon, enabled, builtin, create_time, update_time, deleted)
 VALUES (1000000631, 'GzhPublishTool', 'WeChat OA Publish', 'Publish a generated image-text article to a WeChat Official Account: action=draft uploads the cover and creates a 草稿箱 draft (recommended); action=publish free-publishes for verified accounts and requires explicit confirmation. Needs weixinoa.app_id/app_secret in system settings.', 'builtin', 'gzhPublishTool', '📤', TRUE, TRUE, NOW(), NOW(), 0)
 ON CONFLICT (id) DO UPDATE SET name=EXCLUDED.name, display_name=EXCLUDED.display_name, description=EXCLUDED.description, tool_type=EXCLUDED.tool_type, bean_name=EXCLUDED.bean_name, icon=EXCLUDED.icon, enabled=EXCLUDED.enabled, builtin=EXCLUDED.builtin, update_time=EXCLUDED.update_time, deleted=EXCLUDED.deleted;
-INSERT INTO mate_agent (id, name, description, agent_type, system_prompt, model_name, max_iterations, enabled, icon, tags, create_time, update_time, deleted)
-VALUES (1000000640, 'Content Studio', 'End-to-end 公众号 & 小红书 image-text creation: research, write, illustrate, de-AI, layout, and publish to draft.', 'react', 'You are MateClaw''s Content Studio — a specialist that creates WeChat Official Account (公众号) and Xiaohongshu (小红书) image-text posts end to end.
+INSERT INTO mate_agent (id, workspace_id, name, description, agent_type, system_prompt, model_name, max_iterations, enabled, icon, tags, create_time, update_time, deleted)
+VALUES (1000000640, 0, 'Content Studio', 'End-to-end 公众号 & 小红书 image-text creation: research, write, illustrate, de-AI, layout, and publish to draft.', 'react', 'You are MateClaw''s Content Studio — a specialist that creates WeChat Official Account (公众号) and Xiaohongshu (小红书) image-text posts end to end.
 
 Workflow (7 stages):
 1) Topic — use the topic_interests memory + web_search(freshness=week) to find angles.

--- a/mateclaw-server/src/main/resources/db/data-kingbase-zh.sql
+++ b/mateclaw-server/src/main/resources/db/data-kingbase-zh.sql
@@ -6,18 +6,18 @@ VALUES (1, 'admin', '$2a$10$7JB720yubVSZvUI0rEqK/.VqGOZTH.ulu33dHOiBE8ByOhJIrdAu
 ON CONFLICT (id) DO UPDATE SET username=EXCLUDED.username, password=EXCLUDED.password, nickname=EXCLUDED.nickname, role=EXCLUDED.role, enabled=EXCLUDED.enabled, update_time=EXCLUDED.update_time, deleted=EXCLUDED.deleted;
 
 -- 默认数字员工：通用助手（ReAct 模式）
-INSERT INTO mate_agent (id, name, description, agent_type, system_prompt, model_name, max_iterations, enabled, icon, tags, create_time, update_time, deleted)
-VALUES (1000000001, '通用助手', '日常问答、数据分析、工具调用都能搞定的全能助手', 'react', '你是 MateClaw 的通用助手。你可以帮助用户回答问题、分析数据、调用工具完成任务。请用中文回复，保持专业、友好的态度。', NULL, 100, TRUE, 'pi:robot-face-happy', 'default,assistant', NOW(), NOW(), 0)
+INSERT INTO mate_agent (id, workspace_id, name, description, agent_type, system_prompt, model_name, max_iterations, enabled, icon, tags, create_time, update_time, deleted)
+VALUES (1000000001, 0, '通用助手', '日常问答、数据分析、工具调用都能搞定的全能助手', 'react', '你是 MateClaw 的通用助手。你可以帮助用户回答问题、分析数据、调用工具完成任务。请用中文回复，保持专业、友好的态度。', NULL, 100, TRUE, 'pi:robot-face-happy', 'default,assistant', NOW(), NOW(), 0)
 ON CONFLICT (id) DO UPDATE SET name=EXCLUDED.name, description=EXCLUDED.description, agent_type=EXCLUDED.agent_type, system_prompt=EXCLUDED.system_prompt, model_name=EXCLUDED.model_name, max_iterations=EXCLUDED.max_iterations, enabled=EXCLUDED.enabled, icon=EXCLUDED.icon, tags=EXCLUDED.tags, update_time=EXCLUDED.update_time, deleted=EXCLUDED.deleted;
 
 -- 默认数字员工：任务规划师（Plan-Execute 模式）
-INSERT INTO mate_agent (id, name, description, agent_type, system_prompt, model_name, max_iterations, enabled, icon, tags, create_time, update_time, deleted)
-VALUES (1000000002, '任务规划师', '把复杂目标拆成可执行步骤，逐步推进直到完成', 'plan_execute', '你是一位专业的任务规划师。你擅长将复杂目标分解为可执行的步骤，并逐步完成。请用中文回复。', NULL, 100, TRUE, 'pi:clipboard-note', 'planning,task', NOW(), NOW(), 0)
+INSERT INTO mate_agent (id, workspace_id, name, description, agent_type, system_prompt, model_name, max_iterations, enabled, icon, tags, create_time, update_time, deleted)
+VALUES (1000000002, 0, '任务规划师', '把复杂目标拆成可执行步骤，逐步推进直到完成', 'plan_execute', '你是一位专业的任务规划师。你擅长将复杂目标分解为可执行的步骤，并逐步完成。请用中文回复。', NULL, 100, TRUE, 'pi:clipboard-note', 'planning,task', NOW(), NOW(), 0)
 ON CONFLICT (id) DO UPDATE SET name=EXCLUDED.name, description=EXCLUDED.description, agent_type=EXCLUDED.agent_type, system_prompt=EXCLUDED.system_prompt, model_name=EXCLUDED.model_name, max_iterations=EXCLUDED.max_iterations, enabled=EXCLUDED.enabled, icon=EXCLUDED.icon, tags=EXCLUDED.tags, update_time=EXCLUDED.update_time, deleted=EXCLUDED.deleted;
 
 -- 默认数字员工：推理分析师（显式推理循环 + 工具调用）
-INSERT INTO mate_agent (id, name, description, agent_type, system_prompt, model_name, max_iterations, enabled, icon, tags, create_time, update_time, deleted)
-VALUES (1000000003, '推理分析师', '分步思考、推理过程清晰可见，适合需要"想清楚再回答"的问题', 'react', '你是一位推理分析师，善于深度推理。面对问题时，请先分步思考、清晰呈现推理过程，再调用工具或给出答案。请用中文回复，保持专业、友好的态度。', NULL, 100, TRUE, 'pi:cpu', 'react,reasoning,tools', NOW(), NOW(), 0)
+INSERT INTO mate_agent (id, workspace_id, name, description, agent_type, system_prompt, model_name, max_iterations, enabled, icon, tags, create_time, update_time, deleted)
+VALUES (1000000003, 0, '推理分析师', '分步思考、推理过程清晰可见，适合需要"想清楚再回答"的问题', 'react', '你是一位推理分析师，善于深度推理。面对问题时，请先分步思考、清晰呈现推理过程，再调用工具或给出答案。请用中文回复，保持专业、友好的态度。', NULL, 100, TRUE, 'pi:cpu', 'react,reasoning,tools', NOW(), NOW(), 0)
 ON CONFLICT (id) DO UPDATE SET name=EXCLUDED.name, description=EXCLUDED.description, agent_type=EXCLUDED.agent_type, system_prompt=EXCLUDED.system_prompt, model_name=EXCLUDED.model_name, max_iterations=EXCLUDED.max_iterations, enabled=EXCLUDED.enabled, icon=EXCLUDED.icon, tags=EXCLUDED.tags, update_time=EXCLUDED.update_time, deleted=EXCLUDED.deleted;
 
 -- ==================== 本地模型 Provider（优先展示） ====================
@@ -1834,8 +1834,8 @@ ON CONFLICT (id) DO UPDATE SET name=EXCLUDED.name, display_name=EXCLUDED.display
 INSERT INTO mate_tool (id, name, display_name, description, tool_type, bean_name, icon, enabled, builtin, create_time, update_time, deleted)
 VALUES (1000000631, 'GzhPublishTool', '公众号发布', '将生成的图文发布到微信公众号：action=draft 上传封面并存入草稿箱（推荐）；action=publish 为认证号群发，需显式确认。需在系统设置配置 weixinoa.app_id / weixinoa.app_secret。', 'builtin', 'gzhPublishTool', '📤', TRUE, TRUE, NOW(), NOW(), 0)
 ON CONFLICT (id) DO UPDATE SET name=EXCLUDED.name, display_name=EXCLUDED.display_name, description=EXCLUDED.description, tool_type=EXCLUDED.tool_type, bean_name=EXCLUDED.bean_name, icon=EXCLUDED.icon, enabled=EXCLUDED.enabled, builtin=EXCLUDED.builtin, update_time=EXCLUDED.update_time, deleted=EXCLUDED.deleted;
-INSERT INTO mate_agent (id, name, description, agent_type, system_prompt, model_name, max_iterations, enabled, icon, tags, create_time, update_time, deleted)
-VALUES (1000000640, '内容工作室', '端到端创作公众号与小红书图文：选题搜集、成文、配图、去AI化、排版、入草稿箱发布。', 'react', '你是 MateClaw 的「内容工作室」——专门端到端创作微信公众号（公众号）与小红书图文。
+INSERT INTO mate_agent (id, workspace_id, name, description, agent_type, system_prompt, model_name, max_iterations, enabled, icon, tags, create_time, update_time, deleted)
+VALUES (1000000640, 0, '内容工作室', '端到端创作公众号与小红书图文：选题搜集、成文、配图、去AI化、排版、入草稿箱发布。', 'react', '你是 MateClaw 的「内容工作室」——专门端到端创作微信公众号（公众号）与小红书图文。
 
 工作流（7 段）：
 1）选题——读取 topic_interests 记忆并用 web_search(freshness=week) 找角度。

--- a/mateclaw-server/src/main/resources/db/data-mysql-en.sql
+++ b/mateclaw-server/src/main/resources/db/data-mysql-en.sql
@@ -6,22 +6,22 @@ VALUES (1, 'admin', '$2a$10$7JB720yubVSZvUI0rEqK/.VqGOZTH.ulu33dHOiBE8ByOhJIrdAu
 ON DUPLICATE KEY UPDATE username=VALUES(username), password=VALUES(password), nickname=VALUES(nickname), role=VALUES(role), enabled=VALUES(enabled), update_time=VALUES(update_time), deleted=VALUES(deleted);
 
 -- Default digital employee: General Assistant (ReAct mode)
-INSERT INTO mate_agent (id, name, description, agent_type, system_prompt, model_name, max_iterations, enabled, icon, tags, create_time, update_time, deleted)
-VALUES (1000000001, 'General Assistant', 'All-purpose helper for day-to-day questions, data analysis, and tool calling', 'react',
+INSERT INTO mate_agent (id, workspace_id, name, description, agent_type, system_prompt, model_name, max_iterations, enabled, icon, tags, create_time, update_time, deleted)
+VALUES (1000000001, 0, 'General Assistant', 'All-purpose helper for day-to-day questions, data analysis, and tool calling', 'react',
         'You are MateClaw''s General Assistant. You can help users answer questions, analyze data, and call tools to get things done. Please respond professionally and in a friendly manner.',
         NULL, 100, TRUE, 'pi:robot-face-happy', 'default,assistant', NOW(), NOW(), 0)
 ON DUPLICATE KEY UPDATE name=VALUES(name), description=VALUES(description), agent_type=VALUES(agent_type), system_prompt=VALUES(system_prompt), model_name=VALUES(model_name), max_iterations=VALUES(max_iterations), enabled=VALUES(enabled), icon=VALUES(icon), tags=VALUES(tags), update_time=VALUES(update_time), deleted=VALUES(deleted);
 
 -- Default digital employee: Task Planner (Plan-Execute mode)
-INSERT INTO mate_agent (id, name, description, agent_type, system_prompt, model_name, max_iterations, enabled, icon, tags, create_time, update_time, deleted)
-VALUES (1000000002, 'Task Planner', 'Breaks complex goals into executable steps and drives them forward to completion', 'plan_execute',
+INSERT INTO mate_agent (id, workspace_id, name, description, agent_type, system_prompt, model_name, max_iterations, enabled, icon, tags, create_time, update_time, deleted)
+VALUES (1000000002, 0, 'Task Planner', 'Breaks complex goals into executable steps and drives them forward to completion', 'plan_execute',
         'You are a professional Task Planner. You excel at breaking complex goals into executable steps and completing them systematically.',
         NULL, 100, TRUE, 'pi:clipboard-note', 'planning,task', NOW(), NOW(), 0)
 ON DUPLICATE KEY UPDATE name=VALUES(name), description=VALUES(description), agent_type=VALUES(agent_type), system_prompt=VALUES(system_prompt), model_name=VALUES(model_name), max_iterations=VALUES(max_iterations), enabled=VALUES(enabled), icon=VALUES(icon), tags=VALUES(tags), update_time=VALUES(update_time), deleted=VALUES(deleted);
 
 -- Default digital employee: Reasoning Analyst (explicit reasoning loops + tool calling)
-INSERT INTO mate_agent (id, name, description, agent_type, system_prompt, model_name, max_iterations, enabled, icon, tags, create_time, update_time, deleted)
-VALUES (1000000003, 'Reasoning Analyst', 'Thinks step by step with visible reasoning, ideal for problems that need thorough deliberation', 'react',
+INSERT INTO mate_agent (id, workspace_id, name, description, agent_type, system_prompt, model_name, max_iterations, enabled, icon, tags, create_time, update_time, deleted)
+VALUES (1000000003, 0, 'Reasoning Analyst', 'Thinks step by step with visible reasoning, ideal for problems that need thorough deliberation', 'react',
         'You are a Reasoning Analyst, an assistant that excels at deep reasoning. When facing a problem, first think through it step by step with a clear reasoning trace, then call tools or give the answer. Please respond professionally and in a friendly manner.',
         NULL, 100, TRUE, 'pi:cpu', 'react,reasoning,tools', NOW(), NOW(), 0)
 ON DUPLICATE KEY UPDATE name=VALUES(name), description=VALUES(description), agent_type=VALUES(agent_type), system_prompt=VALUES(system_prompt), model_name=VALUES(model_name), max_iterations=VALUES(max_iterations), enabled=VALUES(enabled), icon=VALUES(icon), tags=VALUES(tags), update_time=VALUES(update_time), deleted=VALUES(deleted);
@@ -1953,8 +1953,8 @@ ON DUPLICATE KEY UPDATE name=VALUES(name), display_name=VALUES(display_name), de
 INSERT INTO mate_tool (id, name, display_name, description, tool_type, bean_name, icon, enabled, builtin, create_time, update_time, deleted)
 VALUES (1000000631, 'GzhPublishTool', 'WeChat OA Publish', 'Publish a generated image-text article to a WeChat Official Account: action=draft uploads the cover and creates a 草稿箱 draft (recommended); action=publish free-publishes for verified accounts and requires explicit confirmation. Needs weixinoa.app_id/app_secret in system settings.', 'builtin', 'gzhPublishTool', '📤', TRUE, TRUE, NOW(), NOW(), 0)
 ON DUPLICATE KEY UPDATE name=VALUES(name), display_name=VALUES(display_name), description=VALUES(description), tool_type=VALUES(tool_type), bean_name=VALUES(bean_name), icon=VALUES(icon), enabled=VALUES(enabled), builtin=VALUES(builtin), update_time=VALUES(update_time), deleted=VALUES(deleted);
-INSERT INTO mate_agent (id, name, description, agent_type, system_prompt, model_name, max_iterations, enabled, icon, tags, create_time, update_time, deleted)
-VALUES (1000000640, 'Content Studio', 'End-to-end 公众号 & 小红书 image-text creation: research, write, illustrate, de-AI, layout, and publish to draft.', 'react', 'You are MateClaw''s Content Studio — a specialist that creates WeChat Official Account (公众号) and Xiaohongshu (小红书) image-text posts end to end.
+INSERT INTO mate_agent (id, workspace_id, name, description, agent_type, system_prompt, model_name, max_iterations, enabled, icon, tags, create_time, update_time, deleted)
+VALUES (1000000640, 0, 'Content Studio', 'End-to-end 公众号 & 小红书 image-text creation: research, write, illustrate, de-AI, layout, and publish to draft.', 'react', 'You are MateClaw''s Content Studio — a specialist that creates WeChat Official Account (公众号) and Xiaohongshu (小红书) image-text posts end to end.
 
 Workflow (7 stages):
 1) Topic — use the topic_interests memory + web_search(freshness=week) to find angles.

--- a/mateclaw-server/src/main/resources/db/data-mysql-zh.sql
+++ b/mateclaw-server/src/main/resources/db/data-mysql-zh.sql
@@ -6,22 +6,22 @@ VALUES (1, 'admin', '$2a$10$7JB720yubVSZvUI0rEqK/.VqGOZTH.ulu33dHOiBE8ByOhJIrdAu
 ON DUPLICATE KEY UPDATE username=VALUES(username), password=VALUES(password), nickname=VALUES(nickname), role=VALUES(role), enabled=VALUES(enabled), update_time=VALUES(update_time), deleted=VALUES(deleted);
 
 -- 默认数字员工：通用助手（ReAct 模式）
-INSERT INTO mate_agent (id, name, description, agent_type, system_prompt, model_name, max_iterations, enabled, icon, tags, create_time, update_time, deleted)
-VALUES (1000000001, '通用助手', '日常问答、数据分析、工具调用都能搞定的全能助手', 'react',
+INSERT INTO mate_agent (id, workspace_id, name, description, agent_type, system_prompt, model_name, max_iterations, enabled, icon, tags, create_time, update_time, deleted)
+VALUES (1000000001, 0, '通用助手', '日常问答、数据分析、工具调用都能搞定的全能助手', 'react',
         '你是 MateClaw 的通用助手。你可以帮助用户回答问题、分析数据、调用工具完成任务。请用中文回复，保持专业、友好的态度。',
         NULL, 100, TRUE, 'pi:robot-face-happy', 'default,assistant', NOW(), NOW(), 0)
 ON DUPLICATE KEY UPDATE name=VALUES(name), description=VALUES(description), agent_type=VALUES(agent_type), system_prompt=VALUES(system_prompt), model_name=VALUES(model_name), max_iterations=VALUES(max_iterations), enabled=VALUES(enabled), icon=VALUES(icon), tags=VALUES(tags), update_time=VALUES(update_time), deleted=VALUES(deleted);
 
 -- 默认数字员工：任务规划师（Plan-Execute 模式）
-INSERT INTO mate_agent (id, name, description, agent_type, system_prompt, model_name, max_iterations, enabled, icon, tags, create_time, update_time, deleted)
-VALUES (1000000002, '任务规划师', '把复杂目标拆成可执行步骤，逐步推进直到完成', 'plan_execute',
+INSERT INTO mate_agent (id, workspace_id, name, description, agent_type, system_prompt, model_name, max_iterations, enabled, icon, tags, create_time, update_time, deleted)
+VALUES (1000000002, 0, '任务规划师', '把复杂目标拆成可执行步骤，逐步推进直到完成', 'plan_execute',
         '你是一位专业的任务规划师。你擅长将复杂目标分解为可执行的步骤，并逐步完成。请用中文回复。',
         NULL, 100, TRUE, 'pi:clipboard-note', 'planning,task', NOW(), NOW(), 0)
 ON DUPLICATE KEY UPDATE name=VALUES(name), description=VALUES(description), agent_type=VALUES(agent_type), system_prompt=VALUES(system_prompt), model_name=VALUES(model_name), max_iterations=VALUES(max_iterations), enabled=VALUES(enabled), icon=VALUES(icon), tags=VALUES(tags), update_time=VALUES(update_time), deleted=VALUES(deleted);
 
 -- 默认数字员工：推理分析师（显式推理循环 + 工具调用）
-INSERT INTO mate_agent (id, name, description, agent_type, system_prompt, model_name, max_iterations, enabled, icon, tags, create_time, update_time, deleted)
-VALUES (1000000003, '推理分析师', '分步思考、推理过程清晰可见，适合需要"想清楚再回答"的问题', 'react',
+INSERT INTO mate_agent (id, workspace_id, name, description, agent_type, system_prompt, model_name, max_iterations, enabled, icon, tags, create_time, update_time, deleted)
+VALUES (1000000003, 0, '推理分析师', '分步思考、推理过程清晰可见，适合需要"想清楚再回答"的问题', 'react',
         '你是一位推理分析师，善于深度推理。面对问题时，请先分步思考、清晰呈现推理过程，再调用工具或给出答案。请用中文回复，保持专业、友好的态度。',
         NULL, 100, TRUE, 'pi:cpu', 'react,reasoning,tools', NOW(), NOW(), 0)
 ON DUPLICATE KEY UPDATE name=VALUES(name), description=VALUES(description), agent_type=VALUES(agent_type), system_prompt=VALUES(system_prompt), model_name=VALUES(model_name), max_iterations=VALUES(max_iterations), enabled=VALUES(enabled), icon=VALUES(icon), tags=VALUES(tags), update_time=VALUES(update_time), deleted=VALUES(deleted);
@@ -1950,8 +1950,8 @@ ON DUPLICATE KEY UPDATE name=VALUES(name), display_name=VALUES(display_name), de
 INSERT INTO mate_tool (id, name, display_name, description, tool_type, bean_name, icon, enabled, builtin, create_time, update_time, deleted)
 VALUES (1000000631, 'GzhPublishTool', '公众号发布', '将生成的图文发布到微信公众号：action=draft 上传封面并存入草稿箱（推荐）；action=publish 为认证号群发，需显式确认。需在系统设置配置 weixinoa.app_id / weixinoa.app_secret。', 'builtin', 'gzhPublishTool', '📤', TRUE, TRUE, NOW(), NOW(), 0)
 ON DUPLICATE KEY UPDATE name=VALUES(name), display_name=VALUES(display_name), description=VALUES(description), tool_type=VALUES(tool_type), bean_name=VALUES(bean_name), icon=VALUES(icon), enabled=VALUES(enabled), builtin=VALUES(builtin), update_time=VALUES(update_time), deleted=VALUES(deleted);
-INSERT INTO mate_agent (id, name, description, agent_type, system_prompt, model_name, max_iterations, enabled, icon, tags, create_time, update_time, deleted)
-VALUES (1000000640, '内容工作室', '端到端创作公众号与小红书图文：选题搜集、成文、配图、去AI化、排版、入草稿箱发布。', 'react', '你是 MateClaw 的「内容工作室」——专门端到端创作微信公众号（公众号）与小红书图文。
+INSERT INTO mate_agent (id, workspace_id, name, description, agent_type, system_prompt, model_name, max_iterations, enabled, icon, tags, create_time, update_time, deleted)
+VALUES (1000000640, 0, '内容工作室', '端到端创作公众号与小红书图文：选题搜集、成文、配图、去AI化、排版、入草稿箱发布。', 'react', '你是 MateClaw 的「内容工作室」——专门端到端创作微信公众号（公众号）与小红书图文。
 
 工作流（7 段）：
 1）选题——读取 topic_interests 记忆并用 web_search(freshness=week) 找角度。

--- a/mateclaw-server/src/main/resources/db/data-zh.sql
+++ b/mateclaw-server/src/main/resources/db/data-zh.sql
@@ -6,23 +6,23 @@ KEY (id)
 VALUES (1, 'admin', '$2a$10$7JB720yubVSZvUI0rEqK/.VqGOZTH.ulu33dHOiBE8ByOhJIrdAu2', 'MateClaw Admin', 'admin', TRUE, NOW(), NOW(), 0);
 
 -- 默认数字员工：通用助手（ReAct 模式）
-MERGE INTO mate_agent (id, name, description, agent_type, system_prompt, model_name, max_iterations, enabled, icon, tags, create_time, update_time, deleted)
+MERGE INTO mate_agent (id, workspace_id, name, description, agent_type, system_prompt, model_name, max_iterations, enabled, icon, tags, create_time, update_time, deleted)
 KEY (id)
-VALUES (1000000001, '通用助手', '日常问答、数据分析、工具调用都能搞定的全能助手', 'react',
+VALUES (1000000001, 0, '通用助手', '日常问答、数据分析、工具调用都能搞定的全能助手', 'react',
         '你是 MateClaw 的通用助手。你可以帮助用户回答问题、分析数据、调用工具完成任务。请用中文回复，保持专业、友好的态度。',
         NULL, 100, TRUE, 'pi:robot-face-happy', 'default,assistant', NOW(), NOW(), 0);
 
 -- 默认数字员工：任务规划师（Plan-Execute 模式）
-MERGE INTO mate_agent (id, name, description, agent_type, system_prompt, model_name, max_iterations, enabled, icon, tags, create_time, update_time, deleted)
+MERGE INTO mate_agent (id, workspace_id, name, description, agent_type, system_prompt, model_name, max_iterations, enabled, icon, tags, create_time, update_time, deleted)
 KEY (id)
-VALUES (1000000002, '任务规划师', '把复杂目标拆成可执行步骤，逐步推进直到完成', 'plan_execute',
+VALUES (1000000002, 0, '任务规划师', '把复杂目标拆成可执行步骤，逐步推进直到完成', 'plan_execute',
         '你是一位专业的任务规划师。你擅长将复杂目标分解为可执行的步骤，并逐步完成。请用中文回复。',
         NULL, 100, TRUE, 'pi:clipboard-note', 'planning,task', NOW(), NOW(), 0);
 
 -- 默认数字员工：推理分析师（显式推理循环 + 工具调用）
-MERGE INTO mate_agent (id, name, description, agent_type, system_prompt, model_name, max_iterations, enabled, icon, tags, create_time, update_time, deleted)
+MERGE INTO mate_agent (id, workspace_id, name, description, agent_type, system_prompt, model_name, max_iterations, enabled, icon, tags, create_time, update_time, deleted)
 KEY (id)
-VALUES (1000000003, '推理分析师', '分步思考、推理过程清晰可见，适合需要"想清楚再回答"的问题', 'react',
+VALUES (1000000003, 0, '推理分析师', '分步思考、推理过程清晰可见，适合需要"想清楚再回答"的问题', 'react',
         '你是一位推理分析师，善于深度推理。面对问题时，请先分步思考、清晰呈现推理过程，再调用工具或给出答案。请用中文回复，保持专业、友好的态度。',
         NULL, 100, TRUE, 'pi:cpu', 'react,reasoning,tools', NOW(), NOW(), 0);
 
@@ -1913,9 +1913,9 @@ VALUES (1000000630, 'WechatArticleExtractTool', '公众号文章抓取', '抓取
 MERGE INTO mate_tool (id, name, display_name, description, tool_type, bean_name, icon, enabled, builtin, create_time, update_time, deleted)
 KEY (id)
 VALUES (1000000631, 'GzhPublishTool', '公众号发布', '将生成的图文发布到微信公众号：action=draft 上传封面并存入草稿箱（推荐）；action=publish 为认证号群发，需显式确认。需在系统设置配置 weixinoa.app_id / weixinoa.app_secret。', 'builtin', 'gzhPublishTool', '📤', TRUE, TRUE, NOW(), NOW(), 0);
-MERGE INTO mate_agent (id, name, description, agent_type, system_prompt, model_name, max_iterations, enabled, icon, tags, create_time, update_time, deleted)
+MERGE INTO mate_agent (id, workspace_id, name, description, agent_type, system_prompt, model_name, max_iterations, enabled, icon, tags, create_time, update_time, deleted)
 KEY (id)
-VALUES (1000000640, '内容工作室', '端到端创作公众号与小红书图文：选题搜集、成文、配图、去AI化、排版、入草稿箱发布。', 'react', '你是 MateClaw 的「内容工作室」——专门端到端创作微信公众号（公众号）与小红书图文。
+VALUES (1000000640, 0, '内容工作室', '端到端创作公众号与小红书图文：选题搜集、成文、配图、去AI化、排版、入草稿箱发布。', 'react', '你是 MateClaw 的「内容工作室」——专门端到端创作微信公众号（公众号）与小红书图文。
 
 工作流（7 段）：
 1）选题——读取 topic_interests 记忆并用 web_search(freshness=week) 找角度。

--- a/mateclaw-server/src/main/resources/db/migration/h2/V175__global_preset_agents.sql
+++ b/mateclaw-server/src/main/resources/db/migration/h2/V175__global_preset_agents.sql
@@ -1,0 +1,20 @@
+-- V175: Make the four built-in preset Agents global (workspace_id = 0).
+--
+-- Background (issue #567): the preset Agents (General Assistant, Task Planner,
+-- Reasoning Analyst, Content Studio) were seeded without workspace_id and thus
+-- fell back to the column default of 1, pinning them to the default workspace.
+-- Any workspace created afterwards (id >= 2) started with an empty agent list,
+-- so sub-agent delegation (delegateToAgent etc.) had no target there.
+--
+-- Fix (B-min): model presets as global, read-only shared records identified by
+-- the reserved workspace_id = 0. AgentService.listAgentsByWorkspace now returns
+-- workspace_id = wsId OR workspace_id = 0, so every workspace sees the presets;
+-- write paths reject mutation of workspace_id = 0 rows (single source of truth).
+-- Fresh installs seed these rows at workspace_id = 0 directly (data-*.sql); this
+-- migration moves the already-seeded rows on existing installs. Idempotent: the
+-- "AND workspace_id <> 0" guard makes re-runs a no-op. Statement is identical
+-- across MySQL / Kingbase / H2.
+UPDATE mate_agent
+SET workspace_id = 0, update_time = NOW()
+WHERE id IN (1000000001, 1000000002, 1000000003, 1000000640)
+  AND workspace_id <> 0;

--- a/mateclaw-server/src/main/resources/db/migration/kingbase/V175__global_preset_agents.sql
+++ b/mateclaw-server/src/main/resources/db/migration/kingbase/V175__global_preset_agents.sql
@@ -1,0 +1,20 @@
+-- V175: Make the four built-in preset Agents global (workspace_id = 0).
+--
+-- Background (issue #567): the preset Agents (General Assistant, Task Planner,
+-- Reasoning Analyst, Content Studio) were seeded without workspace_id and thus
+-- fell back to the column default of 1, pinning them to the default workspace.
+-- Any workspace created afterwards (id >= 2) started with an empty agent list,
+-- so sub-agent delegation (delegateToAgent etc.) had no target there.
+--
+-- Fix (B-min): model presets as global, read-only shared records identified by
+-- the reserved workspace_id = 0. AgentService.listAgentsByWorkspace now returns
+-- workspace_id = wsId OR workspace_id = 0, so every workspace sees the presets;
+-- write paths reject mutation of workspace_id = 0 rows (single source of truth).
+-- Fresh installs seed these rows at workspace_id = 0 directly (data-*.sql); this
+-- migration moves the already-seeded rows on existing installs. Idempotent: the
+-- "AND workspace_id <> 0" guard makes re-runs a no-op. Statement is identical
+-- across MySQL / Kingbase / H2.
+UPDATE mate_agent
+SET workspace_id = 0, update_time = NOW()
+WHERE id IN (1000000001, 1000000002, 1000000003, 1000000640)
+  AND workspace_id <> 0;

--- a/mateclaw-server/src/main/resources/db/migration/mysql/V175__global_preset_agents.sql
+++ b/mateclaw-server/src/main/resources/db/migration/mysql/V175__global_preset_agents.sql
@@ -1,0 +1,20 @@
+-- V175: Make the four built-in preset Agents global (workspace_id = 0).
+--
+-- Background (issue #567): the preset Agents (General Assistant, Task Planner,
+-- Reasoning Analyst, Content Studio) were seeded without workspace_id and thus
+-- fell back to the column default of 1, pinning them to the default workspace.
+-- Any workspace created afterwards (id >= 2) started with an empty agent list,
+-- so sub-agent delegation (delegateToAgent etc.) had no target there.
+--
+-- Fix (B-min): model presets as global, read-only shared records identified by
+-- the reserved workspace_id = 0. AgentService.listAgentsByWorkspace now returns
+-- workspace_id = wsId OR workspace_id = 0, so every workspace sees the presets;
+-- write paths reject mutation of workspace_id = 0 rows (single source of truth).
+-- Fresh installs seed these rows at workspace_id = 0 directly (data-*.sql); this
+-- migration moves the already-seeded rows on existing installs. Idempotent: the
+-- "AND workspace_id <> 0" guard makes re-runs a no-op. Statement is identical
+-- across MySQL / Kingbase / H2.
+UPDATE mate_agent
+SET workspace_id = 0, update_time = NOW()
+WHERE id IN (1000000001, 1000000002, 1000000003, 1000000640)
+  AND workspace_id <> 0;

--- a/mateclaw-server/src/main/resources/messages.properties
+++ b/mateclaw-server/src/main/resources/messages.properties
@@ -227,6 +227,7 @@ err.agent.gemini_not_configured=Gemini Provider \u672a\u5b8c\u6210\u914d\u7f6e
 err.agent.gemini_key_invalid=Gemini API Key \u672a\u914d\u7f6e\u6216\u65e0\u6548
 err.agent.template_not_found=\u6a21\u677f\u4e0d\u5b58\u5728
 err.agent.delete_forbidden=\u53ea\u6709\u521b\u5efa\u8005\u6216\u5de5\u4f5c\u533a\u7ba1\u7406\u5458\u53ef\u5220\u9664\u6b64 Agent
+err.agent.global_preset_readonly=\u5168\u5c40\u9884\u7f6e Agent \u7531\u7cfb\u7edf\u7ef4\u62a4\uff0c\u4e0d\u53ef\u521b\u5efa\u3001\u4fee\u6539\u6216\u5220\u9664
 err.common.wrong_workspace=\u8d44\u6e90\u4e0d\u5c5e\u4e8e\u5f53\u524d\u5de5\u4f5c\u533a
 # llm
 err.llm.model_config_not_found=\u6a21\u578b\u914d\u7f6e\u4e0d\u5b58\u5728

--- a/mateclaw-server/src/main/resources/messages_en.properties
+++ b/mateclaw-server/src/main/resources/messages_en.properties
@@ -239,6 +239,7 @@ err.agent.gemini_not_configured=Gemini Provider not configured
 err.agent.gemini_key_invalid=Gemini API Key not configured or invalid
 err.agent.template_not_found=Template not found
 err.agent.delete_forbidden=Only the creator or a workspace admin can delete this Agent
+err.agent.global_preset_readonly=Global preset Agents are system-managed and cannot be created, modified, or deleted
 err.common.wrong_workspace=Resource does not belong to current workspace
 # llm
 err.llm.model_config_not_found=Model config not found

--- a/mateclaw-server/src/test/java/vip/mate/agent/GlobalPresetAgentTest.java
+++ b/mateclaw-server/src/test/java/vip/mate/agent/GlobalPresetAgentTest.java
@@ -1,0 +1,124 @@
+package vip.mate.agent;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import vip.mate.agent.model.AgentEntity;
+import vip.mate.agent.repository.AgentMapper;
+import vip.mate.exception.MateClawException;
+import vip.mate.memory.MemoryProperties;
+import vip.mate.memory.lifecycle.MemoryLifecycleMediator;
+import vip.mate.memory.service.MemoryRecallTracker;
+import vip.mate.workspace.conversation.repository.ConversationMapper;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * 全局共享预置 Agent（workspace_id = 0，issue #567 / B-min）的只读语义测试。
+ *
+ * <p>覆盖：{@link AgentEntity#isGlobalPreset()} 的判定，以及 {@link AgentService}
+ * 三条用户态写路径（create/update/delete）对全局预置的拒绝。绑定层守卫
+ * （AgentBindingService.requireNotGlobalPreset）是同构镜像，此处不重复搭建其
+ * 10 参构造，靠编译与相同逻辑保障。
+ */
+class GlobalPresetAgentTest {
+
+    private AgentService newService(AgentMapper mapper) {
+        return new AgentService(
+                mapper,
+                mock(AgentGraphBuilder.class),
+                mock(MemoryRecallTracker.class),
+                mock(MemoryLifecycleMediator.class),
+                mock(MemoryProperties.class),
+                mock(vip.mate.memory.identity.MemoryOwnerResolver.class),
+                mock(ConversationMapper.class));
+    }
+
+    private AgentEntity agent(Long id, Long workspaceId) {
+        AgentEntity e = new AgentEntity();
+        e.setId(id);
+        e.setWorkspaceId(workspaceId);
+        e.setName("Some Agent");
+        e.setEnabled(true);
+        return e;
+    }
+
+    // ==================== isGlobalPreset ====================
+
+    @Test
+    @DisplayName("workspace_id=0 判定为全局预置；其它工作区/null 否")
+    void isGlobalPresetDetection() {
+        assertTrue(agent(1L, 0L).isGlobalPreset());
+        assertFalse(agent(2L, 1L).isGlobalPreset());
+        assertFalse(agent(3L, 5L).isGlobalPreset());
+        assertFalse(agent(4L, null).isGlobalPreset());
+    }
+
+    // ==================== createAgent ====================
+
+    @Test
+    @DisplayName("createAgent 拒绝用户传入 workspace_id=0（堵住 X-Workspace-Id:0 漏洞）")
+    void createAgentRejectsGlobalWorkspace() {
+        AgentService service = newService(mock(AgentMapper.class));
+        AgentEntity e = agent(null, 0L);
+        assertThrows(MateClawException.class, () -> service.createAgent(e));
+    }
+
+    @Test
+    @DisplayName("createAgent 允许普通工作区（workspace_id>0）")
+    void createAgentAllowsNormalWorkspace() {
+        AgentMapper mapper = mock(AgentMapper.class);
+        when(mapper.selectCount(any())).thenReturn(0L); // requireUniqueName 通过
+        AgentService service = newService(mapper);
+        AgentEntity e = agent(null, 7L);
+        assertDoesNotThrow(() -> service.createAgent(e));
+        verify(mapper).insert(e);
+    }
+
+    // ==================== updateAgent ====================
+
+    @Test
+    @DisplayName("updateAgent 拒绝修改全局预置")
+    void updateAgentRejectsGlobalPreset() {
+        AgentMapper mapper = mock(AgentMapper.class);
+        when(mapper.selectById(1L)).thenReturn(agent(1L, 0L));
+        AgentService service = newService(mapper);
+
+        AgentEntity incoming = agent(1L, 0L);
+        incoming.setName("Renamed");
+        assertThrows(MateClawException.class, () -> service.updateAgent(incoming));
+        verify(mapper, never()).updateById(any(AgentEntity.class));
+    }
+
+    // ==================== deleteAgent ====================
+
+    @Test
+    @DisplayName("deleteAgent 拒绝删除全局预置")
+    void deleteAgentRejectsGlobalPreset() {
+        AgentMapper mapper = mock(AgentMapper.class);
+        when(mapper.selectById(1L)).thenReturn(agent(1L, 0L));
+        AgentService service = newService(mapper);
+
+        assertThrows(MateClawException.class, () -> service.deleteAgent(1L));
+        verify(mapper, never()).deleteById(anyLong());
+    }
+
+    @Test
+    @DisplayName("deleteAgent 允许删除普通工作区 Agent")
+    void deleteAgentAllowsNormalWorkspace() {
+        AgentMapper mapper = mock(AgentMapper.class);
+        when(mapper.selectById(2L)).thenReturn(agent(2L, 5L));
+        AgentService service = newService(mapper);
+
+        assertDoesNotThrow(() -> service.deleteAgent(2L));
+        verify(mapper).deleteById(2L);
+    }
+}


### PR DESCRIPTION
## 背景 / 问题（#567）

预置 Agent（General Assistant / Task Planner / Reasoning Analyst / Content Studio）的种子 INSERT 省略了 `workspace_id`，落到列默认值 `1`，被钉死在默认工作空间。之后新建的工作空间（id ≥ 2）Agent 列表为空，子代理委派（`delegateToAgent` / `delegateParallel` / `delegateAsync`）没有目标可用。多数用户兜底到默认空间所以感知不到，只有真正使用多工作空间时会撞上。

## 方案（B-min：全局只读共享预置）

把预置建模为 `workspace_id = 0` 的**全局只读共享**记录（产品级配置，而非工作空间私有数据），单一事实源、产品改一处处处生效：

- `AgentService.listAgentsByWorkspace` 返回 `workspace_id = wsId OR workspace_id = 0`，每个工作空间都能看到预置；
- 所有用户态写路径拒绝修改 `workspace_id = 0` 的记录：`AgentService` 的 create/update/delete + `AgentBindingService` 的 8 个绑定 mutator；`createAgent` 同时拒绝用户传入 `workspace_id = 0`（堵住 `X-Workspace-Id: 0`）；新增 i18n 键 `err.agent.global_preset_readonly`；
- `DelegateAgentTool.findAgent` 改为 workspace 感知（本工作区 Agent 优先于全局预置，取排序首条而非 `selectOne`，避免「全局预置 + 本地同名」并存时多结果异常）；
- 种子数据将 4 个预置置为 `workspace_id = 0`；新增 `V175` 迁移把存量安装的预置移到 `workspace_id = 0`（`AND workspace_id <> 0` 保证幂等，三方言正文一致）。

**零 DDL**：不新建表、不加列。`mate_agent.workspace_id` 无外键约束，用保留值 `0` 而非 `NULL` 表示全局，避免改动列约束。

## 测试

- 新增 `GlobalPresetAgentTest`（6 项）：`isGlobalPreset` 判定 + create/update/delete 三条写路径守卫（拒绝全局预置、放行普通工作区）。
- `mvn -pl mateclaw-server -am test -Dtest=GlobalPresetAgentTest` → BUILD SUCCESS，6 项全过。

## 行为变更说明

- 预置对所有工作区变为**只读**；曾自定义默认预置的用户需另建为自己的 Agent（迁移会把存量 ws=1 的预置行无条件提升为全局）。
- 刻意引入受控的「全局 scope」，跨越现有「不返回全局数据」不变量；因预置由产品编写、绑定全局，不含任何工作空间私有数据，安全。

Closes #567
