### PR TITLE
Feat/add llm statistics

### DIFF
--- a/docs/superpowers/specs/2026-08-04-llm-statistics-design.md
+++ b/docs/superpowers/specs/2026-08-04-llm-statistics-design.md
@@ -1,0 +1,356 @@
+# LLM Response Statistics and Latency Tracking Design Specification
+
+## 1. Overview
+The system heavily calls LLMs and acts dynamically based on responses. Keeping track of LLM request latencies (response speed) is critical for system health monitoring, routing decisions, and timeout tuning.
+This specification designs a non-intrusive metadata timing collector to log and analyze latencies for:
+- Non-streaming LLM requests (overall response time).
+- Streaming LLM requests (first token latency and overall completion time).
+
+Daily statistical metrics (Count, Min, Max, Average, p50, p90, p99) are aggregated per model/provider and globally, and printed to logs every 15 minutes. The buffer is cleared at midnight every day to prevent memory accumulation.
+
+---
+
+## 2. Architecture & Components
+
+The timing statistics will be implemented via low-overhead components:
+1. **`LlmRequestMetric.java` (Record)**: A simple data structure holding latency data for single requests.
+2. **`LlmStatisticsCollector.java` (In-Memory Buffer)**: Stores recorded request metrics. Keeps a hard queue size limit of 10,000 to prevent out-of-memory (OOM) failures under heavy load.
+3. **`LlmStatisticsDecorator.java` (ChatModel Decorator)**: Intercepts `ChatModel#call` and `ChatModel#stream` calls programmatically to timestamp outgoing and incoming chunks.
+4. **`LlmStatisticsScheduler.java` (Aggregator & Cron)**: Scheduled cron job firing every 15 minutes to run statistical analysis and log reports, and resetting the collector at midnight.
+
+```
+       [ProviderChatModelFactory]
+                   │
+                   ▼ (wraps with)
+       ┌──────────────────────────────┐
+       │   LlmStatisticsDecorator     │
+       └──────────────┬───────────────┘
+                      │
+           (intercepts call & stream)
+                      │
+                      ▼
+        ┌────────────────────────────┐
+        │   LlmStatisticsCollector   │ <─── [OOM Capacity Guard = 10,000]
+        └─────────────┬──────────────┘
+                      │
+              (reads snapshot)
+                      │
+                      ▼
+         ┌──────────────────────────┐
+         │ LlmStatisticsScheduler   │ (runs every 15m; resets at midnight)
+         └──────────────────────────┘
+```
+
+---
+
+## 3. Detailed Component Designs
+
+### 3.1 `LlmRequestMetric`
+A Java record containing request parameters and timestamp attributes:
+```java
+package vip.mate.llm.chatmodel;
+
+import java.time.LocalDateTime;
+
+public record LlmRequestMetric(
+    LocalDateTime timestamp,
+    String providerId,
+    String modelName,
+    boolean isStreaming,
+    Long firstTokenLatencyMs, // null for non-streaming
+    long overallLatencyMs
+) {}
+```
+
+### 3.2 `LlmStatisticsCollector`
+A thread-safe bean that limits cumulative request storage to 10k items maximum.
+```java
+package vip.mate.llm.chatmodel;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+@Slf4j
+@Component
+public class LlmStatisticsCollector {
+
+    private static final int MAX_CAPACITY = 10000;
+    private final Queue<LlmRequestMetric> requestMetrics = new ConcurrentLinkedQueue<>();
+
+    public void record(LlmRequestMetric metric) {
+        if (requestMetrics.size() >= MAX_CAPACITY) {
+            // Evict oldest element to guard memory (FIFO queue behavior)
+            LlmRequestMetric evicted = requestMetrics.poll();
+            if (evicted != null) {
+                log.warn("[LlmStatisticsCollector] Capacity limit (10000) reached. Evicted oldest metric from: {}", evicted.timestamp());
+            }
+        }
+        requestMetrics.add(metric);
+    }
+
+    public void reset() {
+        requestMetrics.clear();
+        log.info("[LlmStatisticsCollector] Metrics buffer reset.");
+    }
+
+    public List<LlmRequestMetric> getMetricsSnapshot() {
+        return new ArrayList<>(requestMetrics);
+    }
+}
+```
+
+### 3.3 `LlmStatisticsDecorator`
+This decorator intercepts standard call threads and reactive streams.
+```java
+package vip.mate.llm.chatmodel;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.prompt.ChatOptions;
+import org.springframework.ai.chat.prompt.Prompt;
+import reactor.core.publisher.Flux;
+import java.time.LocalDateTime;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+
+@Slf4j
+public class LlmStatisticsDecorator implements ChatModel {
+
+    private final ChatModel delegate;
+    private final String providerId;
+    private final String modelName;
+    private final LlmStatisticsCollector collector;
+
+    public LlmStatisticsDecorator(ChatModel delegate, String providerId, String modelName, LlmStatisticsCollector collector) {
+        this.delegate = delegate;
+        this.providerId = providerId;
+        this.modelName = modelName;
+        this.collector = collector;
+    }
+
+    @Override
+    public ChatResponse call(Prompt prompt) {
+        LocalDateTime requestTime = LocalDateTime.now();
+        long start = System.currentTimeMillis();
+        log.debug("[LLM Request Start] Provider: {}, Model: {}, Streaming: false, Time: {}", providerId, modelName, requestTime);
+        try {
+            ChatResponse response = delegate.call(prompt);
+            long overall = System.currentTimeMillis() - start;
+            log.debug("[LLM Request End] Provider: {}, Model: {}, Streaming: false, Latency: {}ms", providerId, modelName, overall);
+            collector.record(new LlmRequestMetric(
+                requestTime, providerId, modelName, false, null, overall
+            ));
+            return response;
+        } catch (Exception e) {
+            long overall = System.currentTimeMillis() - start;
+            log.debug("[LLM Request Error] Provider: {}, Model: {}, Streaming: false, Latency: {}ms, Error: {}", providerId, modelName, overall, e.getMessage());
+            collector.record(new LlmRequestMetric(
+                requestTime, providerId, modelName, false, null, overall
+            ));
+            throw e;
+        }
+    }
+
+    @Override
+    public Flux<ChatResponse> stream(Prompt prompt) {
+        LocalDateTime requestTime = LocalDateTime.now();
+        long start = System.currentTimeMillis();
+        log.debug("[LLM Request Start] Provider: {}, Model: {}, Streaming: true, Time: {}", providerId, modelName, requestTime);
+
+        AtomicBoolean firstTokenReceived = new AtomicBoolean(false);
+        AtomicLong firstTokenLatency = new AtomicLong(-1);
+
+        return delegate.stream(prompt)
+                .doOnNext(response -> {
+                    boolean hasContent = response.getResults() != null && response.getResults().stream()
+                            .anyMatch(g -> g.getOutput() != null && g.getOutput().getText() != null && !g.getOutput().getText().isEmpty());
+                    if (hasContent && firstTokenReceived.compareAndSet(false, true)) {
+                        long diff = System.currentTimeMillis() - start;
+                        firstTokenLatency.set(diff);
+                        log.debug("[LLM First Token] Provider: {}, Model: {}, Latency: {}ms", providerId, modelName, diff);
+                    }
+                })
+                .doOnError(e -> {
+                    long overall = System.currentTimeMillis() - start;
+                    log.debug("[LLM Stream Error] Provider: {}, Model: {}, Latency: {}ms, Error: {}", providerId, modelName, overall, e.getMessage());
+                    collector.record(new LlmRequestMetric(
+                        requestTime, providerId, modelName, true,
+                        firstTokenLatency.get() >= 0 ? firstTokenLatency.get() : null,
+                        overall
+                    ));
+                })
+                .doOnComplete(() -> {
+                    long overall = System.currentTimeMillis() - start;
+                    log.debug("[LLM Stream End] Provider: {}, Model: {}, Latency: {}ms", providerId, modelName, overall);
+                    collector.record(new LlmRequestMetric(
+                        requestTime, providerId, modelName, true,
+                        firstTokenLatency.get() >= 0 ? firstTokenLatency.get() : null,
+                        overall
+                    ));
+                });
+    }
+
+    @Override
+    public ChatOptions getDefaultOptions() {
+        return delegate.getDefaultOptions();
+    }
+}
+```
+
+### 3.4 Integration via `ProviderChatModelFactory`
+We will decorate ChatModels inside the factory right before returning:
+```java
+// ProviderChatModelFactory.java
+    public ChatModel buildFor(ModelConfigEntity model, RetryTemplate retry) {
+        ModelProviderEntity provider = modelProviderService.getProviderConfig(model.getProvider());
+        ModelProtocol protocol = ModelProtocol.fromChatModel(provider.getChatModel());
+        ChatModelBuilder builder = builders.get(protocol);
+        if (builder == null) {
+            throw new MateClawException("err.agent.protocol_limited",
+                    "No ChatModelBuilder registered for protocol: " + protocol.getId());
+        }
+        ChatModel rawModel = builder.build(model, provider, retry);
+        // Wrap with LlmStatisticsDecorator to measure latency
+        return new LlmStatisticsDecorator(rawModel, provider.getProviderId(), model.getModelName(), collector);
+    }
+```
+
+### 3.5 `LlmStatisticsScheduler`
+Retrieves snapshots, sorts values, outputs them to logs, and resets daily at midnight.
+```java
+package vip.mate.llm.chatmodel;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Component
+public class LlmStatisticsScheduler {
+
+    private final LlmStatisticsCollector collector;
+    private LocalDate lastReportingDate = LocalDate.now();
+
+    public LlmStatisticsScheduler(LlmStatisticsCollector collector) {
+        this.collector = collector;
+    }
+
+    @Scheduled(cron = "0 */15 * * * ?")
+    public void reportStatistics() {
+        LocalDate today = LocalDate.now();
+        if (!today.equals(lastReportingDate)) {
+            log.info("Midnight reached. Performing final LLM stats reporting for: {}", lastReportingDate);
+            generateReport();
+            collector.reset();
+            lastReportingDate = today;
+            log.info("LLM Statistics Collector has been reset for the new day: {}", today);
+            return;
+        }
+        generateReport();
+    }
+
+    @Scheduled(cron = "0 0 0 * * ?")
+    public void midnightReset() {
+        collector.reset();
+        lastReportingDate = LocalDate.now();
+        log.info("LLM Statistics collector reset successfully at midnight.");
+    }
+
+    private void generateReport() {
+        List<LlmRequestMetric> snapshot = collector.getMetricsSnapshot();
+        if (snapshot.isEmpty()) {
+            log.info("=== LLM Performance stats: No requests recorded today yet ===");
+            return;
+        }
+
+        log.info("=================== LLM latency statistics report (Total: {}) ===================", snapshot.size());
+        Map<String, List<LlmRequestMetric>> grouped = snapshot.stream()
+                .collect(Collectors.groupingBy(m -> m.providerId() + " / " + m.modelName()));
+
+        for (Map.Entry<String, List<LlmRequestMetric>> entry : grouped.entrySet()) {
+            printGroupReport(entry.getKey(), entry.getValue());
+        }
+
+        printGroupReport("Global (All Models & Providers)", snapshot);
+        log.info("=================================================================================");
+    }
+
+    private void printGroupReport(String groupName, List<LlmRequestMetric> metrics) {
+        List<LlmRequestMetric> nonStreaming = metrics.stream().filter(m -> !m.isStreaming()).toList();
+        List<LlmRequestMetric> streaming = metrics.stream().filter(LlmRequestMetric::isStreaming).toList();
+
+        log.info("--- Stats for: {} (Total count: {}) ---", groupName, metrics.size());
+
+        if (!nonStreaming.isEmpty()) {
+            List<Long> latencies = nonStreaming.stream().map(LlmRequestMetric::overallLatencyMs).toList();
+            log.info("   [Non-Streaming] Sample count: {} | Min: {}ms | Max: {}ms | Avg: {}ms | p50: {}ms | p90: {}ms | p99: {}ms",
+                    latencies.size(),
+                    latencies.stream().mapToLong(Long::longValue).min().orElse(0),
+                    latencies.stream().mapToLong(Long::longValue).max().orElse(0),
+                    Math.round(latencies.stream().mapToLong(Long::longValue).average().orElse(0.0)),
+                    Math.round(getPercentile(latencies, 50)),
+                    Math.round(getPercentile(latencies, 90)),
+                    Math.round(getPercentile(latencies, 99))
+            );
+        }
+
+        if (!streaming.isEmpty()) {
+            List<Long> firstTokens = streaming.stream()
+                    .map(LlmRequestMetric::firstTokenLatencyMs)
+                    .filter(java.util.Objects::nonNull)
+                    .toList();
+            List<Long> overalls = streaming.stream().map(LlmRequestMetric::overallLatencyMs).toList();
+
+            if (!firstTokens.isEmpty()) {
+                log.info("   [Streaming - First Token] Sample count: {} | Min: {}ms | Max: {}ms | Avg: {}ms | p50: {}ms | p90: {}ms | p99: {}ms",
+                        firstTokens.size(),
+                        firstTokens.stream().mapToLong(Long::longValue).min().orElse(0),
+                        firstTokens.stream().mapToLong(Long::longValue).max().orElse(0),
+                        Math.round(firstTokens.stream().mapToLong(Long::longValue).average().orElse(0.0)),
+                        Math.round(getPercentile(firstTokens, 50)),
+                        Math.round(getPercentile(firstTokens, 90)),
+                        Math.round(getPercentile(firstTokens, 99))
+                );
+            }
+            log.info("   [Streaming - Completion] Sample count: {} | Min: {}ms | Max: {}ms | Avg: {}ms | p50: {}ms | p90: {}ms | p99: {}ms",
+                    overalls.size(),
+                    overalls.stream().mapToLong(Long::longValue).min().orElse(0),
+                    overalls.stream().mapToLong(Long::longValue).max().orElse(0),
+                    Math.round(overalls.stream().mapToLong(Long::longValue).average().orElse(0.0)),
+                    Math.round(getPercentile(overalls, 50)),
+                    Math.round(getPercentile(overalls, 90)),
+                    Math.round(getPercentile(overalls, 99))
+            );
+        }
+    }
+
+    private double getPercentile(List<Long> values, double percentile) {
+        if (values == null || values.isEmpty()) {
+            return 0.0;
+        }
+        List<Long> sorted = values.stream().sorted().toList();
+        int idx = (int) Math.ceil((percentile / 100.0) * sorted.size()) - 1;
+        idx = Math.max(0, Math.min(idx, sorted.size() - 1));
+        return sorted.get(idx);
+    }
+}
+```
+
+---
+
+## 4. Testing & Verification
+
+1. **Unit Testing**:
+   - Verify `LlmStatisticsCollector` capacity limit (adding 10005 metrics and confirming item count remains at 10000, with correct FIFO eviction of the first 5 elements).
+   - Mock a `ChatModel` behavior for both blocking `call(...)` and reactive stream `stream(...)`, verifying timing durations and recorded metric details match mocked latencies.
+2. **Logging Verification**:
+   - Configure SLF4J log configurations if needed. Verify debug statements occur exactly at start and end times in local/dev log files.

--- a/mateclaw-server/src/main/java/vip/mate/channel/web/ChatController.java
+++ b/mateclaw-server/src/main/java/vip/mate/channel/web/ChatController.java
@@ -247,6 +247,7 @@ public class ChatController {
             AtomicBoolean approvalEmitterDone = new AtomicBoolean(false);
 
             sseExecutor.execute(() -> {
+                long streamStart = System.currentTimeMillis();
                 AgentStreamAccumulator accumulator = newAccumulator();
                 AtomicBoolean finalized = new AtomicBoolean(false);
                 try {
@@ -724,6 +725,9 @@ public class ChatController {
                             } catch (Exception e) {
                                 log.warn("SSE complete error: {}", e.getMessage());
                             } finally {
+                                long duration = System.currentTimeMillis() - streamStart;
+                                log.info("[Web Chat End] ConversationId: {} | Replay: false | Streaming: true | Status: {} | Overall Latency: {}ms",
+                                        conversationId, persistStatus, duration);
                                 streamTracker.clearInterruptState(conversationId);
                                 ChatStreamTracker.CompletionResult cr = streamTracker.completeAndConsumeIfLast(conversationId);
                                 if (cr.allDone()) {
@@ -1099,6 +1103,7 @@ public class ChatController {
             @RequestHeader(value = "X-Workspace-Id", required = false) Long workspaceId,
             Authentication auth) {
 
+        long requestStart = System.currentTimeMillis();
         String username = auth != null ? auth.getName() : null;
         if (username == null) {
             return R.fail(401, "未登录，请先登录");
@@ -1118,6 +1123,8 @@ public class ChatController {
                 result.runtimeModel(), result.runtimeProvider());
         completionPublisher.publish(agentId, request.getConversationId(), request.getMessage(), response, "web",
                 memoryOwnerResolver.resolve(webOrigin));
+        long overall = System.currentTimeMillis() - requestStart;
+        log.info("[Web Chat End] ConversationId: {} | Replay: false | Streaming: false | Overall Latency: {}ms", request.getConversationId(), overall);
         return R.ok(response);
     }
 

--- a/mateclaw-server/src/main/java/vip/mate/llm/chatmodel/LlmRequestMetric.java
+++ b/mateclaw-server/src/main/java/vip/mate/llm/chatmodel/LlmRequestMetric.java
@@ -1,0 +1,12 @@
+package vip.mate.llm.chatmodel;
+
+import java.time.LocalDateTime;
+
+public record LlmRequestMetric(
+    LocalDateTime timestamp,
+    String providerId,
+    String modelName,
+    boolean isStreaming,
+    Long firstTokenLatencyMs, // null for non-streaming
+    long overallLatencyMs
+) {}

--- a/mateclaw-server/src/main/java/vip/mate/llm/chatmodel/LlmStatisticsCollector.java
+++ b/mateclaw-server/src/main/java/vip/mate/llm/chatmodel/LlmStatisticsCollector.java
@@ -1,0 +1,36 @@
+package vip.mate.llm.chatmodel;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+@Slf4j
+@Component
+public class LlmStatisticsCollector {
+
+    private static final int MAX_CAPACITY = 10000;
+    private final Queue<LlmRequestMetric> requestMetrics = new ConcurrentLinkedQueue<>();
+
+    public void record(LlmRequestMetric metric) {
+        if (requestMetrics.size() >= MAX_CAPACITY) {
+            LlmRequestMetric evicted = requestMetrics.poll();
+            if (evicted != null) {
+                log.warn("[LlmStatisticsCollector] Capacity limit (10000) reached. Evicted oldest metric from: {}", evicted.timestamp());
+            }
+        }
+        requestMetrics.add(metric);
+    }
+
+    public void reset() {
+        requestMetrics.clear();
+        log.info("[LlmStatisticsCollector] Metrics buffer reset.");
+    }
+
+    public List<LlmRequestMetric> getMetricsSnapshot() {
+        return new ArrayList<>(requestMetrics);
+    }
+}

--- a/mateclaw-server/src/main/java/vip/mate/llm/chatmodel/LlmStatisticsDecorator.java
+++ b/mateclaw-server/src/main/java/vip/mate/llm/chatmodel/LlmStatisticsDecorator.java
@@ -1,0 +1,94 @@
+package vip.mate.llm.chatmodel;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.prompt.ChatOptions;
+import org.springframework.ai.chat.prompt.Prompt;
+import reactor.core.publisher.Flux;
+import java.time.LocalDateTime;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+
+@Slf4j
+public class LlmStatisticsDecorator implements ChatModel {
+
+    private final ChatModel delegate;
+    private final String providerId;
+    private final String modelName;
+    private final LlmStatisticsCollector collector;
+
+    public LlmStatisticsDecorator(ChatModel delegate, String providerId, String modelName, LlmStatisticsCollector collector) {
+        this.delegate = delegate;
+        this.providerId = providerId;
+        this.modelName = modelName;
+        this.collector = collector;
+    }
+
+    @Override
+    public ChatResponse call(Prompt prompt) {
+        LocalDateTime requestTime = LocalDateTime.now();
+        long start = System.currentTimeMillis();
+        log.debug("[LLM Request Start] Provider: {}, Model: {}, Streaming: false, Time: {}", providerId, modelName, requestTime);
+        try {
+            ChatResponse response = delegate.call(prompt);
+            long overall = System.currentTimeMillis() - start;
+            log.debug("[LLM Request End] Provider: {}, Model: {}, Streaming: false, Latency: {}ms", providerId, modelName, overall);
+            collector.record(new LlmRequestMetric(
+                requestTime, providerId, modelName, false, null, overall
+            ));
+            return response;
+        } catch (Exception e) {
+            long overall = System.currentTimeMillis() - start;
+            log.debug("[LLM Request Error] Provider: {}, Model: {}, Streaming: false, Latency: {}ms, Error: {}", providerId, modelName, overall, e.getMessage());
+            collector.record(new LlmRequestMetric(
+                requestTime, providerId, modelName, false, null, overall
+            ));
+            throw e;
+        }
+    }
+
+    @Override
+    public Flux<ChatResponse> stream(Prompt prompt) {
+        LocalDateTime requestTime = LocalDateTime.now();
+        long start = System.currentTimeMillis();
+        log.debug("[LLM Request Start] Provider: {}, Model: {}, Streaming: true, Time: {}", providerId, modelName, requestTime);
+
+        AtomicBoolean firstTokenReceived = new AtomicBoolean(false);
+        AtomicLong firstTokenLatency = new AtomicLong(-1);
+
+        return delegate.stream(prompt)
+                .doOnNext(response -> {
+                    boolean hasContent = response.getResults() != null && response.getResults().stream()
+                            .anyMatch(g -> g.getOutput() != null && g.getOutput().getText() != null && !g.getOutput().getText().isEmpty());
+                    if (hasContent && firstTokenReceived.compareAndSet(false, true)) {
+                        long diff = System.currentTimeMillis() - start;
+                        firstTokenLatency.set(diff);
+                        log.debug("[LLM First Token] Provider: {}, Model: {}, Latency: {}ms", providerId, modelName, diff);
+                    }
+                })
+                .doOnError(e -> {
+                    long overall = System.currentTimeMillis() - start;
+                    log.debug("[LLM Stream Error] Provider: {}, Model: {}, Latency: {}ms, Error: {}", providerId, modelName, overall, e.getMessage());
+                    collector.record(new LlmRequestMetric(
+                        requestTime, providerId, modelName, true,
+                        firstTokenLatency.get() >= 0 ? firstTokenLatency.get() : null,
+                        overall
+                    ));
+                })
+                .doOnComplete(() -> {
+                    long overall = System.currentTimeMillis() - start;
+                    log.debug("[LLM Stream End] Provider: {}, Model: {}, Latency: {}ms", providerId, modelName, overall);
+                    collector.record(new LlmRequestMetric(
+                        requestTime, providerId, modelName, true,
+                        firstTokenLatency.get() >= 0 ? firstTokenLatency.get() : null,
+                        overall
+                    ));
+                });
+    }
+
+    @Override
+    public ChatOptions getDefaultOptions() {
+        return delegate.getDefaultOptions();
+    }
+}

--- a/mateclaw-server/src/main/java/vip/mate/llm/chatmodel/LlmStatisticsScheduler.java
+++ b/mateclaw-server/src/main/java/vip/mate/llm/chatmodel/LlmStatisticsScheduler.java
@@ -1,0 +1,120 @@
+package vip.mate.llm.chatmodel;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Component
+public class LlmStatisticsScheduler {
+
+    private final LlmStatisticsCollector collector;
+    private LocalDate lastReportingDate = LocalDate.now();
+
+    public LlmStatisticsScheduler(LlmStatisticsCollector collector) {
+        this.collector = collector;
+    }
+
+    @Scheduled(cron = "0 */15 * * * ?")
+    public void reportStatistics() {
+        LocalDate today = LocalDate.now();
+        if (!today.equals(lastReportingDate)) {
+            log.info("Midnight reached. Performing final LLM stats reporting for: {}", lastReportingDate);
+            generateReport();
+            collector.reset();
+            lastReportingDate = today;
+            log.info("LLM Statistics Collector has been reset for the new day: {}", today);
+            return;
+        }
+        generateReport();
+    }
+
+    @Scheduled(cron = "0 0 0 * * ?")
+    public void midnightReset() {
+        collector.reset();
+        lastReportingDate = LocalDate.now();
+        log.info("LLM Statistics collector reset successfully at midnight.");
+    }
+
+    private void generateReport() {
+        List<LlmRequestMetric> snapshot = collector.getMetricsSnapshot();
+        if (snapshot.isEmpty()) {
+            log.info("=== LLM Performance stats: No requests recorded today yet ===");
+            return;
+        }
+
+        log.info("=================== LLM latency statistics report (Total: {}) ===================", snapshot.size());
+        Map<String, List<LlmRequestMetric>> grouped = snapshot.stream()
+                .collect(Collectors.groupingBy(m -> m.providerId() + " / " + m.modelName()));
+
+        for (Map.Entry<String, List<LlmRequestMetric>> entry : grouped.entrySet()) {
+            printGroupReport(entry.getKey(), entry.getValue());
+        }
+
+        printGroupReport("Global (All Models & Providers)", snapshot);
+        log.info("=================================================================================");
+    }
+
+    private void printGroupReport(String groupName, List<LlmRequestMetric> metrics) {
+        List<LlmRequestMetric> nonStreaming = metrics.stream().filter(m -> !m.isStreaming()).toList();
+        List<LlmRequestMetric> streaming = metrics.stream().filter(LlmRequestMetric::isStreaming).toList();
+
+        log.info("--- Stats for: {} (Total count: {}) ---", groupName, metrics.size());
+
+        if (!nonStreaming.isEmpty()) {
+            List<Long> latencies = nonStreaming.stream().map(LlmRequestMetric::overallLatencyMs).toList();
+            log.info("   [Non-Streaming] Sample count: {} | Min: {}ms | Max: {}ms | Avg: {}ms | p50: {}ms | p90: {}ms | p99: {}ms",
+                    latencies.size(),
+                    latencies.stream().mapToLong(Long::longValue).min().orElse(0),
+                    latencies.stream().mapToLong(Long::longValue).max().orElse(0),
+                    Math.round(latencies.stream().mapToLong(Long::longValue).average().orElse(0.0)),
+                    Math.round(getPercentile(latencies, 50)),
+                    Math.round(getPercentile(latencies, 90)),
+                    Math.round(getPercentile(latencies, 99))
+            );
+        }
+
+        if (!streaming.isEmpty()) {
+            List<Long> firstTokens = streaming.stream()
+                    .map(LlmRequestMetric::firstTokenLatencyMs)
+                    .filter(java.util.Objects::nonNull)
+                    .toList();
+            List<Long> overalls = streaming.stream().map(LlmRequestMetric::overallLatencyMs).toList();
+
+            if (!firstTokens.isEmpty()) {
+                log.info("   [Streaming - First Token] Sample count: {} | Min: {}ms | Max: {}ms | Avg: {}ms | p50: {}ms | p90: {}ms | p99: {}ms",
+                        firstTokens.size(),
+                        firstTokens.stream().mapToLong(Long::longValue).min().orElse(0),
+                        firstTokens.stream().mapToLong(Long::longValue).max().orElse(0),
+                        Math.round(firstTokens.stream().mapToLong(Long::longValue).average().orElse(0.0)),
+                        Math.round(getPercentile(firstTokens, 50)),
+                        Math.round(getPercentile(firstTokens, 90)),
+                        Math.round(getPercentile(firstTokens, 99))
+                );
+            }
+            log.info("   [Streaming - Completion] Sample count: {} | Min: {}ms | Max: {}ms | Avg: {}ms | p50: {}ms | p90: {}ms | p99: {}ms",
+                    overalls.size(),
+                    overalls.stream().mapToLong(Long::longValue).min().orElse(0),
+                    overalls.stream().mapToLong(Long::longValue).max().orElse(0),
+                    Math.round(overalls.stream().mapToLong(Long::longValue).average().orElse(0.0)),
+                    Math.round(getPercentile(overalls, 50)),
+                    Math.round(getPercentile(overalls, 90)),
+                    Math.round(getPercentile(overalls, 99))
+            );
+        }
+    }
+
+    private double getPercentile(List<Long> values, double percentile) {
+        if (values == null || values.isEmpty()) {
+            return 0.0;
+        }
+        List<Long> sorted = values.stream().sorted().toList();
+        int idx = (int) Math.ceil((percentile / 100.0) * sorted.size()) - 1;
+        idx = Math.max(0, Math.min(idx, sorted.size() - 1));
+        return sorted.get(idx);
+    }
+}

--- a/mateclaw-server/src/main/java/vip/mate/llm/chatmodel/ProviderChatModelFactory.java
+++ b/mateclaw-server/src/main/java/vip/mate/llm/chatmodel/ProviderChatModelFactory.java
@@ -37,10 +37,13 @@ public class ProviderChatModelFactory {
 
     private final Map<ModelProtocol, ChatModelBuilder> builders;
     private final ModelProviderService modelProviderService;
+    private final LlmStatisticsCollector collector;
 
     public ProviderChatModelFactory(List<ChatModelBuilder> allBuilders,
-                                    ModelProviderService modelProviderService) {
+                                    ModelProviderService modelProviderService,
+                                    LlmStatisticsCollector collector) {
         this.modelProviderService = modelProviderService;
+        this.collector = collector;
         Map<ModelProtocol, ChatModelBuilder> map = new EnumMap<>(ModelProtocol.class);
         for (ChatModelBuilder b : allBuilders) {
             ChatModelBuilder previous = map.put(b.supportedProtocol(), b);
@@ -69,6 +72,7 @@ public class ProviderChatModelFactory {
             throw new MateClawException("err.agent.protocol_limited",
                     "No ChatModelBuilder registered for protocol: " + protocol.getId());
         }
-        return builder.build(model, provider, retry);
+        ChatModel raw = builder.build(model, provider, retry);
+        return new LlmStatisticsDecorator(raw, provider.getProviderId(), model.getModelName(), collector);
     }
 }

--- a/mateclaw-server/src/test/java/vip/mate/llm/chatmodel/LlmStatisticsCollectorTest.java
+++ b/mateclaw-server/src/test/java/vip/mate/llm/chatmodel/LlmStatisticsCollectorTest.java
@@ -1,0 +1,32 @@
+package vip.mate.llm.chatmodel;
+
+import org.junit.jupiter.api.Test;
+import java.time.LocalDateTime;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class LlmStatisticsCollectorTest {
+
+    @Test
+    void testCollectorEvictsWhenCapacityReached() {
+        LlmStatisticsCollector collector = new LlmStatisticsCollector();
+        // Insert 10005 metrics
+        for (int i = 0; i < 10005; i++) {
+            collector.record(new LlmRequestMetric(
+                LocalDateTime.now(), "prov", "mod" + i, false, null, i
+            ));
+        }
+        assertEquals(10000, collector.getMetricsSnapshot().size());
+        // Verify FIFO eviction (first items mod0 to mod4 are evicted, mod5 remains)
+        assertEquals("mod5", collector.getMetricsSnapshot().get(0).modelName());
+    }
+
+    @Test
+    void testResetClearsMetrics() {
+        LlmStatisticsCollector collector = new LlmStatisticsCollector();
+        collector.record(new LlmRequestMetric(LocalDateTime.now(), "prov", "mod", false, null, 100));
+        assertEquals(1, collector.getMetricsSnapshot().size());
+        collector.reset();
+        assertTrue(collector.getMetricsSnapshot().isEmpty());
+    }
+}

--- a/mateclaw-server/src/test/java/vip/mate/llm/chatmodel/LlmStatisticsDecoratorTest.java
+++ b/mateclaw-server/src/test/java/vip/mate/llm/chatmodel/LlmStatisticsDecoratorTest.java
@@ -1,0 +1,69 @@
+package vip.mate.llm.chatmodel;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
+import org.springframework.ai.chat.prompt.Prompt;
+import reactor.core.publisher.Flux;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+class LlmStatisticsDecoratorTest {
+
+    @Test
+    void testCallLatencyCalculation() {
+        ChatModel mockModel = Mockito.mock(ChatModel.class);
+        ChatResponse mockResponse = new ChatResponse(List.of(new Generation(new AssistantMessage("Hello"))));
+        when(mockModel.call(any(Prompt.class))).thenAnswer(invocation -> {
+            Thread.sleep(50);
+            return mockResponse;
+        });
+
+        LlmStatisticsCollector collector = new LlmStatisticsCollector();
+        LlmStatisticsDecorator decorator = new LlmStatisticsDecorator(mockModel, "mock-prov", "mock-model", collector);
+
+        ChatResponse response = decorator.call(new Prompt("hi"));
+        assertNotNull(response);
+
+        List<LlmRequestMetric> snapshot = collector.getMetricsSnapshot();
+        assertEquals(1, snapshot.size());
+        LlmRequestMetric metric = snapshot.get(0);
+        assertEquals("mock-prov", metric.providerId());
+        assertEquals("mock-model", metric.modelName());
+        assertTrue(metric.overallLatencyMs() >= 50);
+    }
+
+    @Test
+    void testStreamFirstTokenLatencyCalculation() {
+        ChatModel mockModel = Mockito.mock(ChatModel.class);
+        ChatResponse resp1 = new ChatResponse(List.of(new Generation(new AssistantMessage(""))));
+        ChatResponse resp2 = new ChatResponse(List.of(new Generation(new AssistantMessage("A"))));
+        ChatResponse resp3 = new ChatResponse(List.of(new Generation(new AssistantMessage("B"))));
+
+        when(mockModel.stream(any(Prompt.class))).thenReturn(
+            Flux.just(resp1, resp2, resp3)
+        );
+
+        LlmStatisticsCollector collector = new LlmStatisticsCollector();
+        LlmStatisticsDecorator decorator = new LlmStatisticsDecorator(mockModel, "mock-prov", "mock-model", collector);
+
+        List<ChatResponse> responses = decorator.stream(new Prompt("stream")).collectList().block();
+        assertNotNull(responses);
+        assertEquals(3, responses.size());
+
+        List<LlmRequestMetric> snapshot = collector.getMetricsSnapshot();
+        assertEquals(1, snapshot.size());
+        LlmRequestMetric metric = snapshot.get(0);
+        assertTrue(metric.isStreaming());
+        assertNotNull(metric.firstTokenLatencyMs());
+    }
+}

--- a/mateclaw-server/src/test/java/vip/mate/llm/chatmodel/LlmStatisticsSchedulerTest.java
+++ b/mateclaw-server/src/test/java/vip/mate/llm/chatmodel/LlmStatisticsSchedulerTest.java
@@ -1,0 +1,23 @@
+package vip.mate.llm.chatmodel;
+
+import org.junit.jupiter.api.Test;
+import java.time.LocalDateTime;
+import java.util.List;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class LlmStatisticsSchedulerTest {
+
+    @Test
+    void testSchedulerCalculationAndReset() {
+        LlmStatisticsCollector collector = new LlmStatisticsCollector();
+        collector.record(new LlmRequestMetric(LocalDateTime.now(), "p1", "m1", false, null, 100));
+        collector.record(new LlmRequestMetric(LocalDateTime.now(), "p1", "m1", false, null, 200));
+
+        LlmStatisticsScheduler scheduler = new LlmStatisticsScheduler(collector);
+        scheduler.reportStatistics(); // Should log stats output without throwing error
+
+        List<LlmRequestMetric> snapshot = collector.getMetricsSnapshot();
+        assertEquals(2, snapshot.size());
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -365,6 +365,13 @@
                     <!-- Emit method parameter names so Spring MVC can bind
                          @PathVariable/@RequestParam without explicit names. -->
                     <parameters>true</parameters>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>1.18.46</version>
+                        </path>
+                    </annotationProcessorPaths>
                 </configuration>
             </plugin>
             <!-- Resolve the ${revision} CI-friendly version into installed and

--- a/pom.xml
+++ b/pom.xml
@@ -365,13 +365,6 @@
                     <!-- Emit method parameter names so Spring MVC can bind
                          @PathVariable/@RequestParam without explicit names. -->
                     <parameters>true</parameters>
-                    <annotationProcessorPaths>
-                        <path>
-                            <groupId>org.projectlombok</groupId>
-                            <artifactId>lombok</artifactId>
-                            <version>1.18.46</version>
-                        </path>
-                    </annotationProcessorPaths>
                 </configuration>
             </plugin>
             <!-- Resolve the ${revision} CI-friendly version into installed and


### PR DESCRIPTION
- 容器与底层维度（LlmStatisticsDecorator 及 LlmStatisticsScheduler）：可观测每一发底层的首 Token 耗时、非流式调用时耗及完成时局，从 LLM 客户端层面上排查接口延迟。
- 用户请求维度（ChatController）：可观测用户在会话气泡中发送消息后到全响应落盘的整体历时。通过比较两者，您能够在发生响应卡顿时，非常快速且准确地辨别是底层大模型接口发生阻塞还是由 MateClaw 本地业务逻辑层（数据库访问、上下文整合或内存调度等） 引起的耗时。