### PR TITLE
log(webchat): raise SSE timeout/error lifecycle logs to INFO (#586)

### DIFF
--- a/mateclaw-server/src/main/java/vip/mate/channel/webchat/WebChatController.java
+++ b/mateclaw-server/src/main/java/vip/mate/channel/webchat/WebChatController.java
@@ -196,14 +196,23 @@ public class WebChatController {
             streamTracker.detach(conversationId, emitter);
         });
         emitter.onTimeout(() -> {
-            log.debug("[WebChat] SSE timeout: {}", conversationId);
+            // INFO: a timeout means the stream went idle past the SseEmitter
+            // budget, which is a key signal when diagnosing stream stalls.
+            log.info("[WebChat] SSE timeout (stream went idle past the emitter budget): {}", conversationId);
             streamTracker.detach(conversationId, emitter);
             // Explicitly complete after timeout so the servlet container does
             // not rethrow AsyncRequestTimeoutException.
             emitter.complete();
         });
         emitter.onError(e -> {
-            log.debug("[WebChat] SSE error: {} - {}", conversationId, e.getMessage());
+            // INFO only for non-benign causes; a client simply closing the tab
+            // (broken pipe / connection reset) is routine and stays DEBUG so it
+            // doesn't flood production logs.
+            if (isClientDisconnect(e)) {
+                log.debug("[WebChat] SSE client disconnected: {} - {}", conversationId, e.getMessage());
+            } else {
+                log.info("[WebChat] SSE error: {} - {}", conversationId, e.getMessage());
+            }
             streamTracker.detach(conversationId, emitter);
         });
 
@@ -1262,12 +1271,16 @@ public class WebChatController {
             streamTracker.detach(conversationId, emitter);
         });
         emitter.onTimeout(() -> {
-            log.debug("[WebChat] approve SSE timeout: {}", conversationId);
+            log.info("[WebChat] approve SSE timeout (stream went idle past the emitter budget): {}", conversationId);
             streamTracker.detach(conversationId, emitter);
             emitter.complete();
         });
         emitter.onError(e -> {
-            log.debug("[WebChat] approve SSE error: {} - {}", conversationId, e.getMessage());
+            if (isClientDisconnect(e)) {
+                log.debug("[WebChat] approve SSE client disconnected: {} - {}", conversationId, e.getMessage());
+            } else {
+                log.info("[WebChat] approve SSE error: {} - {}", conversationId, e.getMessage());
+            }
             streamTracker.detach(conversationId, emitter);
         });
 
@@ -1415,6 +1428,22 @@ public class WebChatController {
         } catch (NumberFormatException e) {
             return null;
         }
+    }
+
+    /**
+     * True when the SSE error is a routine client-side disconnect (closed tab,
+     * network drop) rather than a server-side failure. Used to keep the
+     * lifecycle log noise down: a visitor closing the tab is expected and
+     * stays DEBUG; anything else is worth an INFO line for production triage.
+     * Mirrors ChatController#isClientDisconnect.
+     */
+    private static boolean isClientDisconnect(Throwable e) {
+        if (e instanceof IOException) return true;
+        String msg = e.getMessage();
+        if (msg == null) return false;
+        String lower = msg.toLowerCase();
+        return lower.contains("broken pipe") || lower.contains("connection reset")
+                || lower.contains("client abort") || lower.contains("closed");
     }
 
     /**


### PR DESCRIPTION
对应 #586 的 b 项。从 #586 主修复（done/error 关流 + 可配置超时，见 #589）中拆出——按单一关注点要求，无关的日志级别调整混进 bugfix PR 有被要求回退的风险。

## 问题

webchat SSE 的 `timeout` / `error` 生命周期日志全是 DEBUG 级，生产 INFO 下排障时，下游集成方实际命中的故障类型（流空闲超过 emitter 预算 vs 服务端错误 vs 常规客户端断开）完全无迹可循——事故时运维只能凭空猜。

## 修复

- `onTimeout` → **INFO**：超时意味着流空闲超过了 emitter 预算，是这一类卡死故障的关键信号。
- `onError` → **仅非良性原因抬 INFO**。访客关闭标签页（broken pipe / connection reset）是常态，保持 DEBUG 以免刷屏生产日志；新增的 `isClientDisconnect()` 分类器对位 `ChatController`。
- `onCompletion` 保持 **DEBUG**：它在每次正常完成时都触发，没有排障价值。

`/stream` 和 `/sessions/approve` 两处都改。无行为变更——纯可观测性。

## 范围

单一关注点：webchat SSE 生命周期回调的日志级别。无测试（日志级别改动没有可锁定的回归）。