### PR TITLE
feat: add optional you.com search integration

### DIFF
--- a/mateclaw-plugin-you-search/pom.xml
+++ b/mateclaw-plugin-you-search/pom.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>vip.mate</groupId>
+        <artifactId>mateclaw</artifactId>
+        <version>${revision}</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>mateclaw-plugin-you-search</artifactId>
+    <packaging>jar</packaging>
+
+    <name>MateClaw You.com Search Provider Plugin</name>
+    <description>
+        Optional community plugin that adds You.com as a web-search provider via the MateClaw
+        Plugin SDK. Implements PluginSearchProvider against the You.com Search API
+        (POST /v1/search with X-API-Key auth). Not in the default stack; users must build
+        the JAR and install it into the plugins/ directory, then configure their You.com
+        API key in the plugin admin UI.
+    </description>
+
+    <dependencies>
+        <!-- MateClaw Plugin API -->
+        <dependency>
+            <groupId>vip.mate</groupId>
+            <artifactId>mateclaw-plugin-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Spring AI (provided by the platform) — PluginContext method signatures
+             reference ToolCallback/ChatModel, so it must be resolvable at compile time -->
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-model</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Jackson (provided by the platform parent classloader) -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- SLF4J (provided by the platform) -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Test only -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- slf4j-simple: gives the plugin a real logger during tests so
+             LoggerFactory.getLogger doesn't fall back to NOP silently -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/mateclaw-plugin-you-search/src/main/java/vip/mate/plugin/yousearch/YouSearchClient.java
+++ b/mateclaw-plugin-you-search/src/main/java/vip/mate/plugin/yousearch/YouSearchClient.java
@@ -1,0 +1,165 @@
+package vip.mate.plugin.yousearch;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Thin HTTP client for the You.com Search API.
+ * <p>
+ * Covers the single endpoint used by {@link YouSearchProvider}:
+ * {@code POST /v1/search} with {@code X-API-Key} auth. Request body fields:
+ * {@code query}, {@code count}, {@code freshness}, {@code country},
+ * {@code language}, {@code safesearch}. Response shape:
+ * {@code {"results":{"web":[...],"news":[...]},"metadata":{...}}} where each
+ * web result carries {@code url}, {@code title}, {@code description},
+ * {@code snippets} and {@code page_age}.
+ *
+ * <p>Failure semantics: every call either returns a parsed result or throws
+ * {@link YouSearchException}. The platform's provider chain catches and falls
+ * through to the next provider.
+ *
+ * @author Mouse Parker
+ */
+class YouSearchClient {
+
+    private final YouSearchConfig config;
+    private final HttpClient http;
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    YouSearchClient(YouSearchConfig config) {
+        this.config = config;
+        this.http = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofMillis(Math.max(1000, config.timeoutMs())))
+                .build();
+    }
+
+    /**
+     * Execute a You.com web search.
+     *
+     * @param query     search keywords
+     * @param count     max results (clamped by the platform to 1-10 before this call)
+     * @param freshness optional time-range filter: day / week / month / year
+     * @param language  optional BCP 47 language preference, e.g. en / zh-CN
+     * @return web results, possibly empty; never null
+     * @throws YouSearchException on non-2xx response or IO error
+     */
+    List<YouSearchHit> search(String query, Integer count, String freshness, String language) {
+        ObjectNode body = mapper.createObjectNode();
+        body.put("query", query);
+        if (count != null) {
+            body.put("count", count);
+        }
+        if (freshness != null && !freshness.isBlank()) {
+            body.put("freshness", freshness.toLowerCase());
+        }
+        if (language != null && !language.isBlank()) {
+            body.put("language", language);
+        }
+        if (config.normalizedCountry() != null) {
+            body.put("country", config.normalizedCountry());
+        }
+        if (config.normalizedSafesearch() != null) {
+            body.put("safesearch", config.normalizedSafesearch());
+        }
+
+        JsonNode resp = post("/v1/search", body);
+        return parseWebResults(resp);
+    }
+
+    /**
+     * Map the response onto flat hits. The You.com API returns web and news
+     * sections; both share the result shape, so both are collected — web first
+     * (ranked relevance), then news.
+     */
+    private List<YouSearchHit> parseWebResults(JsonNode resp) {
+        List<YouSearchHit> out = new ArrayList<>();
+        JsonNode results = resp.path("results");
+        collect(results.path("web"), out);
+        collect(results.path("news"), out);
+        return out;
+    }
+
+    private void collect(JsonNode items, List<YouSearchHit> out) {
+        if (!items.isArray()) {
+            return;
+        }
+        for (JsonNode item : items) {
+            String url = item.path("url").asText(null);
+            String title = item.path("title").asText(null);
+            String snippet = firstSnippet(item);
+            String date = item.path("page_age").asText(null);
+            if (url == null && title == null && snippet == null) {
+                continue; // skip empty entries
+            }
+            out.add(new YouSearchHit(title, url, snippet, domainOf(url), date));
+        }
+    }
+
+    /**
+     * Prefer the first element of {@code snippets}; fall back to {@code description}.
+     */
+    private static String firstSnippet(JsonNode item) {
+        JsonNode snippets = item.path("snippets");
+        if (snippets.isArray() && snippets.size() > 0) {
+            String s = snippets.get(0).asText(null);
+            if (s != null && !s.isBlank()) {
+                return s;
+            }
+        }
+        return item.path("description").asText(null);
+    }
+
+    private static String domainOf(String url) {
+        if (url == null || url.isBlank()) {
+            return null;
+        }
+        try {
+            return URI.create(url).getHost();
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    /**
+     * Shared POST helper. Returns the parsed JSON body on 2xx.
+     *
+     * @throws YouSearchException on non-2xx response or IO error
+     */
+    private JsonNode post(String path, ObjectNode body) {
+        String url = config.normalizedBaseUrl() + path;
+        try {
+            String payload = mapper.writeValueAsString(body);
+            HttpRequest.Builder req = HttpRequest.newBuilder(URI.create(url))
+                    .timeout(Duration.ofMillis(config.timeoutMs()))
+                    .header("Content-Type", "application/json")
+                    .header("X-API-Key", config.apiKey())
+                    .POST(HttpRequest.BodyPublishers.ofString(payload));
+
+            HttpResponse<String> resp = http.send(req.build(), HttpResponse.BodyHandlers.ofString());
+            int code = resp.statusCode();
+            if (code < 200 || code >= 300) {
+                throw new YouSearchException("You.com " + path + " returned HTTP " + code
+                        + ": " + truncate(resp.body(), 500));
+            }
+            return mapper.readTree(resp.body() == null ? "{}" : resp.body());
+        } catch (YouSearchException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new YouSearchException("You.com " + path + " request failed: " + e.getMessage(), e);
+        }
+    }
+
+    private static String truncate(String s, int max) {
+        if (s == null) return "";
+        return s.length() > max ? s.substring(0, max) + "..." : s;
+    }
+}

--- a/mateclaw-plugin-you-search/src/main/java/vip/mate/plugin/yousearch/YouSearchConfig.java
+++ b/mateclaw-plugin-you-search/src/main/java/vip/mate/plugin/yousearch/YouSearchConfig.java
@@ -1,0 +1,66 @@
+package vip.mate.plugin.yousearch;
+
+/**
+ * You.com search plugin configuration snapshot.
+ * <p>
+ * Read once from {@code PluginContext#getConfig} at plugin load time and passed
+ * to {@link YouSearchClient} / {@link YouSearchProvider}. Snapshot semantics —
+ * config changes require a plugin reload.
+ *
+ * @param apiKey    You.com API key, sent as the {@code X-API-Key} header (required for the provider to be available)
+ * @param baseUrl   You.com Search API base URL; null/blank falls back to the default
+ * @param country   optional country code for geographical focus, e.g. "us"
+ * @param safesearch optional content moderation filter: strict / moderate / off
+ * @param timeoutMs HTTP timeout for search calls
+ * @author Mouse Parker
+ */
+record YouSearchConfig(
+        String apiKey,
+        String baseUrl,
+        String country,
+        String safesearch,
+        int timeoutMs
+) {
+    static final String DEFAULT_BASE_URL = "https://ydc-index.io";
+    static final int DEFAULT_TIMEOUT_MS = 15000;
+
+    /**
+     * Whether this provider should participate at all.
+     * You.com search without an API key is unusable; treat as unavailable.
+     */
+    boolean isUsable() {
+        return apiKey != null && !apiKey.isBlank();
+    }
+
+    /**
+     * Effective base URL: configured value or the You.com Search API default.
+     * Trailing slashes are stripped to avoid double-slash in path joins.
+     */
+    String normalizedBaseUrl() {
+        String url = (baseUrl == null || baseUrl.isBlank()) ? DEFAULT_BASE_URL : baseUrl;
+        while (url.endsWith("/")) {
+            url = url.substring(0, url.length() - 1);
+        }
+        return url;
+    }
+
+    /**
+     * Safesearch value as the API spells it (lowercase); null when unset.
+     */
+    String normalizedSafesearch() {
+        if (safesearch == null || safesearch.isBlank()) {
+            return null;
+        }
+        return safesearch.toLowerCase();
+    }
+
+    /**
+     * Country code as the API spells it (lowercase); null when unset.
+     */
+    String normalizedCountry() {
+        if (country == null || country.isBlank()) {
+            return null;
+        }
+        return country.toLowerCase();
+    }
+}

--- a/mateclaw-plugin-you-search/src/main/java/vip/mate/plugin/yousearch/YouSearchException.java
+++ b/mateclaw-plugin-you-search/src/main/java/vip/mate/plugin/yousearch/YouSearchException.java
@@ -1,0 +1,21 @@
+package vip.mate.plugin.yousearch;
+
+/**
+ * Thrown when a You.com Search API call fails (non-2xx or transport error).
+ * <p>
+ * The platform's provider chain treats a thrown provider as failed and falls
+ * through to the next provider, so this exception is the failure signal —
+ * callers must not swallow it.
+ *
+ * @author Mouse Parker
+ */
+class YouSearchException extends RuntimeException {
+
+    YouSearchException(String message) {
+        super(message);
+    }
+
+    YouSearchException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/mateclaw-plugin-you-search/src/main/java/vip/mate/plugin/yousearch/YouSearchHit.java
+++ b/mateclaw-plugin-you-search/src/main/java/vip/mate/plugin/yousearch/YouSearchHit.java
@@ -1,0 +1,21 @@
+package vip.mate.plugin.yousearch;
+
+/**
+ * A single You.com search hit, flattened from the API's web/news result shape
+ * into the fields {@link YouSearchProvider} needs.
+ *
+ * @param title   result title (nullable)
+ * @param url     result link (nullable)
+ * @param snippet first snippet, or description (nullable)
+ * @param source  source domain, e.g. "reuters.com" (nullable)
+ * @param date    page age as raw string (nullable)
+ * @author Mouse Parker
+ */
+record YouSearchHit(
+        String title,
+        String url,
+        String snippet,
+        String source,
+        String date
+) {
+}

--- a/mateclaw-plugin-you-search/src/main/java/vip/mate/plugin/yousearch/YouSearchPlugin.java
+++ b/mateclaw-plugin-you-search/src/main/java/vip/mate/plugin/yousearch/YouSearchPlugin.java
@@ -1,0 +1,86 @@
+package vip.mate.plugin.yousearch;
+
+import org.slf4j.Logger;
+import vip.mate.plugin.api.MateClawPlugin;
+import vip.mate.plugin.api.PluginContext;
+
+/**
+ * MateClaw plugin entrypoint that registers {@link YouSearchProvider} with the
+ * platform's search provider chain.
+ * <p>
+ * Lifecycle:
+ * <ol>
+ *   <li>{@code onLoad} — read config from {@link PluginContext}, build
+ *       {@link YouSearchConfig} → {@link YouSearchClient} → {@link YouSearchProvider},
+ *       then {@code context.registerSearchProvider(provider)}.
+ *       If no API key is configured, the provider is registered but reports
+ *       {@code isAvailable()=false} — the platform silently skips it.</li>
+ *   <li>{@code onEnable} / {@code onDisable} — lifecycle log only.</li>
+ * </ol>
+ *
+ * <p>This plugin is NOT part of the default stack. Users must:
+ * <ol>
+ *   <li>Get a You.com API key at https://you.com/platform/api-keys</li>
+ *   <li>Build the plugin JAR ({@code mvn -pl mateclaw-plugin-you-search -am package})
+ *       and drop it into the platform's {@code plugins/} directory</li>
+ *   <li>Configure {@code apiKey} (and optionally {@code baseUrl} / {@code country} /
+ *       {@code safesearch} / {@code timeoutMs}) via the plugin admin UI</li>
+ * </ol>
+ *
+ * @author Mouse Parker
+ */
+public class YouSearchPlugin implements MateClawPlugin {
+
+    private static final String CONFIG_API_KEY = "apiKey";
+    private static final String CONFIG_BASE_URL = "baseUrl";
+    private static final String CONFIG_COUNTRY = "country";
+    private static final String CONFIG_SAFESEARCH = "safesearch";
+    private static final String CONFIG_TIMEOUT_MS = "timeoutMs";
+
+    private Logger log;
+
+    @Override
+    public void onLoad(PluginContext context) {
+        this.log = context.getLogger();
+
+        YouSearchConfig config = readConfig(context);
+        if (!config.isUsable()) {
+            log.warn("You.com search plugin loaded without apiKey — provider will stay unavailable. "
+                    + "Configure 'apiKey' in the plugin config to enable.");
+        }
+
+        YouSearchClient client = new YouSearchClient(config);
+        YouSearchProvider provider = new YouSearchProvider(config, client);
+        context.registerSearchProvider(provider);
+
+        log.info("You.com search plugin loaded: baseUrl={}, country={}, safesearch={}, timeoutMs={}",
+                config.normalizedBaseUrl(), config.normalizedCountry(),
+                config.normalizedSafesearch(), config.timeoutMs());
+    }
+
+    @Override
+    public void onEnable() {
+        if (log != null) log.info("You.com search plugin enabled");
+    }
+
+    @Override
+    public void onDisable() {
+        if (log != null) log.info("You.com search plugin disabled");
+    }
+
+    private YouSearchConfig readConfig(PluginContext ctx) {
+        String apiKey = ctx.getConfig(CONFIG_API_KEY, String.class);
+        String baseUrl = ctx.getConfig(CONFIG_BASE_URL, String.class);
+        String country = ctx.getConfig(CONFIG_COUNTRY, String.class);
+        String safesearch = ctx.getConfig(CONFIG_SAFESEARCH, String.class);
+        Integer timeoutMs = ctx.getConfig(CONFIG_TIMEOUT_MS, Integer.class);
+
+        return new YouSearchConfig(
+                apiKey,
+                baseUrl,
+                country,
+                safesearch,
+                timeoutMs == null ? YouSearchConfig.DEFAULT_TIMEOUT_MS : timeoutMs
+        );
+    }
+}

--- a/mateclaw-plugin-you-search/src/main/java/vip/mate/plugin/yousearch/YouSearchProvider.java
+++ b/mateclaw-plugin-you-search/src/main/java/vip/mate/plugin/yousearch/YouSearchProvider.java
@@ -1,0 +1,82 @@
+package vip.mate.plugin.yousearch;
+
+import vip.mate.plugin.api.search.PluginSearchProvider;
+import vip.mate.plugin.api.search.PluginSearchQuery;
+import vip.mate.plugin.api.search.PluginSearchResult;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Search provider that bridges MateClaw's {@code web_search} provider chain to
+ * the You.com Search API.
+ * <p>
+ * Query mapping: {@link PluginSearchQuery#query()} / {@code count()} /
+ * {@code freshness()} / {@code language()} map 1:1 onto the API's
+ * {@code query} / {@code count} / {@code freshness} / {@code language} request
+ * fields — both sides use the same day/week/month/year vocabulary and BCP 47
+ * language codes, so no translation layer is needed.
+ * <p>
+ * Result mapping: the API's web (and news) results carry
+ * {@code title} / {@code url} / {@code snippets[0]} (or {@code description}) /
+ * {@code page_age}; the source domain is derived from the URL.
+ * <p>
+ * Failure semantics: {@code search} throws {@link YouSearchException} on any
+ * failure — per the SPI contract, the platform catches and falls through to
+ * the next provider in the chain.
+ *
+ * @author Mouse Parker
+ */
+class YouSearchProvider implements PluginSearchProvider {
+
+    static final String ID = "you";
+
+    private final YouSearchConfig config;
+    private final YouSearchClient client;
+
+    YouSearchProvider(YouSearchConfig config, YouSearchClient client) {
+        this.config = config;
+        this.client = client;
+    }
+
+    @Override
+    public String id() {
+        return ID;
+    }
+
+    @Override
+    public String label() {
+        return "You.com";
+    }
+
+    @Override
+    public boolean requiresCredential() {
+        return true;
+    }
+
+    @Override
+    public boolean isAvailable() {
+        // Cheap config check only — no network I/O, per the SPI contract.
+        return config.isUsable();
+    }
+
+    @Override
+    public List<PluginSearchResult> search(PluginSearchQuery query) {
+        List<YouSearchHit> hits = client.search(
+                query.query(),
+                query.count(),
+                query.freshness(),
+                query.language());
+
+        List<PluginSearchResult> results = new ArrayList<>(hits.size());
+        for (YouSearchHit hit : hits) {
+            results.add(new PluginSearchResult(
+                    hit.title(),
+                    hit.url(),
+                    hit.snippet(),
+                    hit.source(),
+                    hit.date()));
+        }
+        return results;
+    }
+}

--- a/mateclaw-plugin-you-search/src/main/resources/mateclaw-plugin.json
+++ b/mateclaw-plugin-you-search/src/main/resources/mateclaw-plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "mateclaw-plugin-you-search",
+  "version": "1.0.0",
+  "type": "search",
+  "displayName": "You.com Search Provider (Optional)",
+  "description": "Adds You.com as a web-search provider via the You.com Search API (X-API-Key auth). Joins the web_search provider chain alongside serper / tavily / searxng / duckduckgo. Requires a You.com API key. Not part of the default stack.",
+  "entrypoint": "vip.mate.plugin.yousearch.YouSearchPlugin",
+  "minPlatformVersion": "2.0.0",
+  "author": "Mouse Parker",
+  "config": {
+    "apiKey": {
+      "type": "string",
+      "required": true,
+      "secret": true,
+      "description": "You.com API key (X-API-Key header). Get one at https://you.com/platform/api-keys"
+    },
+    "baseUrl": {
+      "type": "string",
+      "required": false,
+      "secret": false,
+      "description": "You.com Search API base URL. Default https://ydc-index.io"
+    },
+    "country": {
+      "type": "string",
+      "required": false,
+      "secret": false,
+      "description": "Country code for geographical focus of results, e.g. us / de. Optional."
+    },
+    "safesearch": {
+      "type": "string",
+      "required": false,
+      "secret": false,
+      "description": "Content moderation filter: strict / moderate / off. Default off."
+    },
+    "timeoutMs": {
+      "type": "integer",
+      "required": false,
+      "secret": false,
+      "description": "HTTP timeout in milliseconds. Default 15000."
+    }
+  }
+}

--- a/mateclaw-plugin-you-search/src/test/java/vip/mate/plugin/yousearch/YouSearchClientTest.java
+++ b/mateclaw-plugin-you-search/src/test/java/vip/mate/plugin/yousearch/YouSearchClientTest.java
@@ -1,0 +1,161 @@
+package vip.mate.plugin.yousearch;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class YouSearchClientTest {
+
+    private HttpServer server;
+    private YouSearchClient client;
+    private final AtomicReference<String> lastBody = new AtomicReference<>();
+    private final AtomicReference<String> lastApiKeyHeader = new AtomicReference<>();
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @BeforeEach
+    void setUp() throws IOException {
+        // Capture request details so each test can assert what was sent.
+        HttpHandler handler = this::handle;
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/", handler);
+        server.start();
+
+        String baseUrl = "http://127.0.0.1:" + server.getAddress().getPort();
+        YouSearchConfig config = new YouSearchConfig("test-key", baseUrl, null, null, 5000);
+        client = new YouSearchClient(config);
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (server != null) server.stop(0);
+    }
+
+    private void handle(HttpExchange exchange) throws IOException {
+        lastBody.set(readBody(exchange));
+        lastApiKeyHeader.set(exchange.getRequestHeaders().getFirst("X-API-Key"));
+        byte[] resp = ("{\"results\":{\"web\":["
+                + "{\"url\":\"https://example.com/a\",\"title\":\"First\","
+                + "\"description\":\"desc one\",\"snippets\":[\"snippet one\",\"snippet two\"],"
+                + "\"page_age\":\"2026-09-01T00:00:00Z\"},"
+                + "{\"url\":\"https://example.com/b\",\"title\":\"Second\","
+                + "\"description\":\"desc two\"}"
+                + "],\"news\":["
+                + "{\"url\":\"https://news.example.com/c\",\"title\":\"News item\","
+                + "\"snippets\":[\"news snippet\"],\"page_age\":\"2026-09-02T00:00:00Z\"}"
+                + "]},\"metadata\":{}}").getBytes(StandardCharsets.UTF_8);
+        exchange.getResponseHeaders().add("Content-Type", "application/json");
+        exchange.sendResponseHeaders(200, resp.length);
+        exchange.getResponseBody().write(resp);
+        exchange.close();
+    }
+
+    private static String readBody(HttpExchange exchange) throws IOException {
+        try (InputStream in = exchange.getRequestBody()) {
+            return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        }
+    }
+
+    @Test
+    void search_sendsQueryCountFreshnessAndLanguageInBody() throws Exception {
+        client.search("spring boot release", 5, "Month", "en-US");
+
+        assertThat(lastApiKeyHeader.get()).isEqualTo("test-key");
+
+        JsonNode body = mapper.readTree(lastBody.get());
+        assertThat(body.get("query").asText()).isEqualTo("spring boot release");
+        assertThat(body.get("count").asInt()).isEqualTo(5);
+        assertThat(body.get("freshness").asText()).isEqualTo("month"); // lowercased
+        assertThat(body.get("language").asText()).isEqualTo("en-US");
+    }
+
+    @Test
+    void search_omitsAbsentOptionalFields() throws Exception {
+        client.search("plain query", null, null, null);
+
+        JsonNode body = mapper.readTree(lastBody.get());
+        assertThat(body.has("count")).isFalse();
+        assertThat(body.has("freshness")).isFalse();
+        assertThat(body.has("language")).isFalse();
+    }
+
+    @Test
+    void search_sendsConfiguredCountryAndSafesearch() throws Exception {
+        YouSearchConfig cfg = new YouSearchConfig(
+                "test-key", "http://127.0.0.1:" + server.getAddress().getPort(), "US", "Strict", 5000);
+        YouSearchClient withOptions = new YouSearchClient(cfg);
+
+        withOptions.search("query", 3, null, null);
+
+        JsonNode body = mapper.readTree(lastBody.get());
+        assertThat(body.get("country").asText()).isEqualTo("us");
+        assertThat(body.get("safesearch").asText()).isEqualTo("strict");
+    }
+
+    @Test
+    void search_parsesWebThenNewsResults() {
+        List<YouSearchHit> hits = client.search("anything", 10, null, null);
+
+        assertThat(hits).hasSize(3); // 2 web + 1 news
+
+        YouSearchHit first = hits.get(0);
+        assertThat(first.title()).isEqualTo("First");
+        assertThat(first.url()).isEqualTo("https://example.com/a");
+        // snippets[0] wins over description
+        assertThat(first.snippet()).isEqualTo("snippet one");
+        assertThat(first.source()).isEqualTo("example.com");
+        assertThat(first.date()).isEqualTo("2026-09-01T00:00:00Z");
+
+        // no snippets → description fallback; no page_age → null date
+        YouSearchHit second = hits.get(1);
+        assertThat(second.snippet()).isEqualTo("desc two");
+        assertThat(second.date()).isNull();
+
+        // news section is collected too
+        YouSearchHit news = hits.get(2);
+        assertThat(news.title()).isEqualTo("News item");
+        assertThat(news.source()).isEqualTo("news.example.com");
+    }
+
+    @Test
+    void non2xxResponseThrowsYouSearchException() {
+        server.removeContext("/");
+        server.createContext("/", ex -> {
+            byte[] resp = "{\"message\":\"Forbidden\"}".getBytes(StandardCharsets.UTF_8);
+            ex.sendResponseHeaders(403, resp.length);
+            ex.getResponseBody().write(resp);
+            ex.close();
+        });
+
+        assertThatThrownBy(() -> client.search("q", 5, null, null))
+                .isInstanceOf(YouSearchException.class)
+                .hasMessageContaining("HTTP 403");
+    }
+
+    @Test
+    void connectionFailureThrowsYouSearchException() {
+        // Stop the server, then call — should fail with connection refused.
+        int port = server.getAddress().getPort();
+        server.stop(0);
+        YouSearchConfig cfg = new YouSearchConfig("test-key", "http://127.0.0.1:" + port, null, null, 500);
+        YouSearchClient deadClient = new YouSearchClient(cfg);
+
+        assertThatThrownBy(() -> deadClient.search("q", 5, null, null))
+                .isInstanceOf(YouSearchException.class)
+                .hasMessageContaining("request failed");
+    }
+}

--- a/mateclaw-plugin-you-search/src/test/java/vip/mate/plugin/yousearch/YouSearchPluginTest.java
+++ b/mateclaw-plugin-you-search/src/test/java/vip/mate/plugin/yousearch/YouSearchPluginTest.java
@@ -1,0 +1,193 @@
+package vip.mate.plugin.yousearch;
+
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.tool.ToolCallback;
+import vip.mate.plugin.api.PluginContext;
+import vip.mate.plugin.api.PluginException;
+import vip.mate.plugin.api.channel.PluginChannelAdapter;
+import vip.mate.plugin.api.memory.PluginMemoryProvider;
+import vip.mate.plugin.api.search.PluginSearchProvider;
+import vip.mate.plugin.api.search.PluginSearchQuery;
+import vip.mate.plugin.api.search.PluginSearchResult;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class YouSearchPluginTest {
+
+    @Test
+    void onLoad_readsConfigAndRegistersProvider() {
+        Map<String, Object> config = new HashMap<>();
+        config.put("apiKey", "secret");
+        config.put("timeoutMs", 8000);
+
+        AtomicReference<PluginSearchProvider> registered = new AtomicReference<>();
+        PluginContext ctx = new StubContext(config, registered);
+
+        YouSearchPlugin plugin = new YouSearchPlugin();
+        plugin.onLoad(ctx);
+        plugin.onEnable();
+
+        PluginSearchProvider p = registered.get();
+        assertThat(p).isNotNull();
+        assertThat(p.id()).isEqualTo("you");
+        assertThat(p.label()).isEqualTo("You.com");
+        assertThat(p.requiresCredential()).isTrue();
+        assertThat(p.isAvailable()).isTrue(); // apiKey set
+
+        plugin.onDisable();
+    }
+
+    @Test
+    void onLoad_withMissingApiKey_stillRegistersButUnavailable() {
+        // No apiKey configured — plugin should register but report unavailable
+        // rather than throwing, so it can be enabled later via config.
+        Map<String, Object> config = new HashMap<>(); // empty
+        AtomicReference<PluginSearchProvider> registered = new AtomicReference<>();
+        PluginContext ctx = new StubContext(config, registered);
+
+        YouSearchPlugin plugin = new YouSearchPlugin();
+        plugin.onLoad(ctx);
+
+        PluginSearchProvider p = registered.get();
+        assertThat(p).isNotNull();
+        assertThat(p.isAvailable()).isFalse();
+    }
+
+    @Test
+    void onLoad_appliesDefaultTimeout() {
+        // Only apiKey set — timeoutMs should default (no exception, available).
+        Map<String, Object> config = new HashMap<>();
+        config.put("apiKey", "secret");
+
+        AtomicReference<PluginSearchProvider> registered = new AtomicReference<>();
+        PluginContext ctx = new StubContext(config, registered);
+
+        YouSearchPlugin plugin = new YouSearchPlugin();
+        plugin.onLoad(ctx);
+
+        assertThat(registered.get().isAvailable()).isTrue();
+    }
+
+    @Test
+    void onLoad_throwsWhenContextRejectsClashingId() {
+        // Simulate the platform's unique-id constraint by throwing from
+        // registerSearchProvider.
+        Map<String, Object> config = new HashMap<>();
+        config.put("apiKey", "secret");
+        AtomicReference<PluginSearchProvider> registered = new AtomicReference<>();
+        PluginContext ctx = new StubContext(config, registered) {
+            @Override
+            public void registerSearchProvider(PluginSearchProvider provider) {
+                throw new PluginException("provider id already taken: you");
+            }
+        };
+
+        YouSearchPlugin plugin = new YouSearchPlugin();
+        assertThatThrownBy(() -> plugin.onLoad(ctx))
+                .isInstanceOf(PluginException.class)
+                .hasMessageContaining("already taken");
+    }
+
+    @Test
+    void provider_mapsQueryFieldsOntoApiCall() {
+        // Wire the provider against a stub client to verify the SPI query
+        // is translated into the client call — freshness/language/count pass
+        // through unchanged (same vocabulary on both sides).
+        RecordingClient client = new RecordingClient();
+        YouSearchConfig config = new YouSearchConfig("k", null, null, null, 15000);
+        YouSearchProvider provider = new YouSearchProvider(config, client);
+
+        List<PluginSearchResult> out = provider.search(
+                new PluginSearchQuery("spring ai release", "month", "zh-CN", 5));
+
+        assertThat(client.query).isEqualTo("spring ai release");
+        assertThat(client.count).isEqualTo(5);
+        assertThat(client.freshness).isEqualTo("month");
+        assertThat(client.language).isEqualTo("zh-CN");
+
+        assertThat(out).hasSize(1);
+        PluginSearchResult r = out.get(0);
+        assertThat(r.title()).isEqualTo("t");
+        assertThat(r.url()).isEqualTo("u");
+        assertThat(r.snippet()).isEqualTo("s");
+        assertThat(r.source()).isEqualTo("src");
+        assertThat(r.date()).isEqualTo("d");
+    }
+
+    /**
+     * Stub client that records the last call and returns one canned hit.
+     */
+    private static final class RecordingClient extends YouSearchClient {
+        String query;
+        Integer count;
+        String freshness;
+        String language;
+
+        RecordingClient() {
+            super(new YouSearchConfig("k", "http://127.0.0.1:1", null, null, 100));
+        }
+
+        @Override
+        List<YouSearchHit> search(String query, Integer count, String freshness, String language) {
+            this.query = query;
+            this.count = count;
+            this.freshness = freshness;
+            this.language = language;
+            return List.of(new YouSearchHit("t", "u", "s", "src", "d"));
+        }
+    }
+
+    /**
+     * Minimal PluginContext stub: only getConfig / registerSearchProvider /
+     * getLogger are exercised by YouSearchPlugin; everything else throws.
+     */
+    static class StubContext implements PluginContext {
+        private final Map<String, Object> config;
+        private final AtomicReference<PluginSearchProvider> registered;
+
+        StubContext(Map<String, Object> config, AtomicReference<PluginSearchProvider> registered) {
+            this.config = config;
+            this.registered = registered;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> T getConfig(String key, Class<T> type) {
+            Object v = config.get(key);
+            if (v == null) return null;
+            if (type.isInstance(v)) return (T) v;
+            // Best-effort scalar coercion for Integer/Boolean from String/Number
+            if (type == Integer.class && v instanceof Number n) return (T) (Integer) n.intValue();
+            if (type == Boolean.class && v instanceof Boolean b) return (T) b;
+            return null;
+        }
+
+        @Override
+        public Logger getLogger() {
+            return LoggerFactory.getLogger("test.YouSearchPlugin");
+        }
+
+        @Override
+        public void registerSearchProvider(PluginSearchProvider provider) {
+            registered.set(provider);
+        }
+
+        // The remaining methods are not used by YouSearchPlugin; stub them out.
+
+        @Override public void registerTool(ToolCallback tool) { throw new UnsupportedOperationException(); }
+        @Override public void registerTool(ToolCallback tool, Supplier<Boolean> availabilityCheck) { throw new UnsupportedOperationException(); }
+        @Override public void registerProvider(String providerId, ChatModel chatModel) { throw new UnsupportedOperationException(); }
+        @Override public void registerChannel(PluginChannelAdapter channel) { throw new UnsupportedOperationException(); }
+        @Override public void registerMemoryProvider(PluginMemoryProvider provider) { throw new UnsupportedOperationException(); }
+    }
+}

--- a/mateclaw-server/src/main/resources/docs/en/tools.md
+++ b/mateclaw-server/src/main/resources/docs/en/tools.md
@@ -155,6 +155,33 @@ Features:
 - **Security wrapping** — results sanitized before return.
 - **Provider-native + tool search coexistence** — models with their own search (ChatGPT, Gemini) can use that natively while tool search is available as fallback.
 
+#### You.com provider (optional plugin)
+
+::: warning Not in the default stack
+The You.com provider is an **optional community plugin** (`mateclaw-plugin-you-search`) — it is NOT part of a default MateClaw install. It requires a You.com API key. The built-in provider chain (DuckDuckGo / SearXNG / Serper / Tavily) is untouched; the plugin adds a `you` provider that joins the chain once installed and configured.
+:::
+
+[You.com](https://you.com) provides a web search API with `freshness` / `language` / `count` parameters matching the tool's own vocabulary, so the plugin maps them 1:1. Results carry title, URL, snippet, source domain, and page age.
+
+Installation:
+
+1. **Get an API key** at [you.com/platform/api-keys](https://you.com/platform/api-keys).
+2. **Build the plugin JAR**: from the MateClaw repo root, run `mvn -pl mateclaw-plugin-you-search -am package` — the JAR lands at `mateclaw-plugin-you-search/target/mateclaw-plugin-you-search-*.jar`.
+3. **Drop the JAR** into MateClaw's `plugins/` directory.
+4. **Configure**: in the plugin admin UI, set `apiKey` (required) and optionally `country`, `safesearch`, and `timeoutMs`. Restart or reload the plugin.
+
+Configuration:
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `apiKey` | string | yes | — | You.com API key, sent as the `X-API-Key` header |
+| `baseUrl` | string | no | `https://ydc-index.io` | You.com Search API base URL (override for proxies) |
+| `country` | string | no | — | Country code for geographical focus, e.g. `us` / `de` |
+| `safesearch` | string | no | — | Content moderation filter: `strict` / `moderate` / `off` |
+| `timeoutMs` | integer | no | `15000` | HTTP timeout in milliseconds |
+
+Once configured, select `you` under `Settings → System → Search Service` (or leave it on auto-detect — the provider participates in the chain whenever it is available). On any API error the provider throws and the platform falls through to the next provider, so a You.com outage degrades gracefully.
+
 ### ShellExecuteTool
 
 Cross-platform shell execution. Linux/macOS uses `/bin/sh -c`; Windows uses `cmd.exe /D /S /C`. **Every call is gated by Tool Guard.**

--- a/mateclaw-server/src/main/resources/docs/zh/tools.md
+++ b/mateclaw-server/src/main/resources/docs/zh/tools.md
@@ -155,6 +155,33 @@ Tool Guard 是守门员。超时是**每个工具独立**的（这样一个慢�
 - **安全包装**——结果返回前先净化
 - **原生搜索 + 工具搜索共存**——自带搜索的模型用原生搜索，工具搜索作为 fallback
 
+#### You.com 供应商（可选插件）
+
+::: warning 不在默认安装中
+You.com 供应商是一个**可选社区插件**（`mateclaw-plugin-you-search`）——**不属于** MateClaw 默认安装，需要 You.com API Key。内置供应商链（DuckDuckGo / SearXNG / Serper / Tavily）不受影响；插件安装并配置后会作为 `you` 供应商加入链中。
+:::
+
+[You.com](https://you.com) 提供的搜索 API 支持 `freshness` / `language` / `count` 参数，与工具自身的参数词汇一致，因此一一映射。结果包含标题、URL、摘要、来源域名和页面时间。
+
+安装步骤：
+
+1. 在 [you.com/platform/api-keys](https://you.com/platform/api-keys) **获取 API Key**。
+2. **构建插件 JAR**：在 MateClaw 仓库根目录执行 `mvn -pl mateclaw-plugin-you-search -am package`，JAR 输出在 `mateclaw-plugin-you-search/target/mateclaw-plugin-you-search-*.jar`。
+3. 将 JAR 放入 MateClaw 的 `plugins/` 目录。
+4. 在插件管理界面**配置**：`apiKey`（必填），可选 `country`、`safesearch`、`timeoutMs`。重启或重载插件。
+
+配置项：
+
+| 字段 | 类型 | 必填 | 默认值 | 说明 |
+|------|------|------|--------|------|
+| `apiKey` | string | 是 | — | You.com API Key，以 `X-API-Key` 头发送 |
+| `baseUrl` | string | 否 | `https://ydc-index.io` | You.com 搜索 API 地址（可用于代理） |
+| `country` | string | 否 | — | 结果地理聚焦的国家代码，如 `us` / `cn` |
+| `safesearch` | string | 否 | — | 内容过滤级别：`strict` / `moderate` / `off` |
+| `timeoutMs` | integer | 否 | `15000` | HTTP 超时（毫秒） |
+
+配置完成后，在 `设置 → 系统设置 → 搜索服务` 选择 `you`（或保持自动——供应商可用时即参与链）。API 出错时供应商抛出异常，平台自动 fallback 到下一个供应商，You.com 故障时优雅降级。
+
 ### ShellExecuteTool
 
 跨平台 shell 执行。Linux/macOS 用 `/bin/sh -c`，Windows 用 `cmd.exe /D /S /C`。**每一次调用都过 Tool Guard。**

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
         <module>mateclaw-plugin-sample</module>
         <module>mateclaw-plugin-search-sample</module>
         <module>mateclaw-plugin-mem0</module>
+        <module>mateclaw-plugin-you-search</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
## What this adds

An **optional** `mateclaw-plugin-you-search` module that adds [You.com](https://you.com) as a web-search provider via the existing `PluginSearchProvider` SPI. The `web_search` provider chain currently offers serper / tavily (keyed) and searxng / duckduckgo (keyless); this adds a `you` provider for users who have a You.com API key. Nothing changes for anyone who doesn't install the plugin — it's a drop-in JAR, not a server dependency.

## Why this fits the plugin design

I followed the plugin search-provider design (`docs/superpowers/specs/2026-07-03-plugin-search-provider-design.md`) and mirrored the `mateclaw-plugin-mem0` module structure exactly:

- `mateclaw-plugin.json` manifest with a config schema (`apiKey` required/secret, `baseUrl` / `country` / `safesearch` / `timeoutMs` optional) so it's configurable from the plugin admin UI
- provided-scope dependencies only (plugin-api, spring-ai-model, jackson, slf4j) — no new runtime deps for the platform
- registers via `context.registerSearchProvider(...)`; if no API key is configured, the provider is registered but reports `isAvailable()=false` and the platform silently skips it

The query mapping turned out to be 1:1 — the plugin SPI's `freshness` (day/week/month/year), `language` (BCP 47), and `count` match the You.com Search API's request fields directly, so there's no translation layer. Web and news results map onto `PluginSearchResult` with `snippets[0]` (falling back to `description`) as the snippet, the URL host as source, and `page_age` as date.

## Setup

1. Get an API key at https://you.com/platform/api-keys
2. `mvn -pl mateclaw-plugin-you-search -am package` → drop the JAR into `plugins/`
3. Set `apiKey` (and optionally `country` / `safesearch` / `timeoutMs` / `baseUrl`) in the plugin admin UI

Then `you` appears in `Settings → System → Search Service` and joins the provider chain.

## Error behavior

On any non-2xx or transport error the client throws `YouSearchException`, and per the SPI contract the platform catches it and falls through to the next provider — a You.com outage degrades the same way a Serper outage does. The `isAvailable()` check is config-only (no network I/O), per the SPI's cheapness requirement.

## Validation

- `mvn -pl mateclaw-plugin-you-search -am test` — **11/11 tests pass** (Java 21, Temurin 21.0.12)
  - `YouSearchClientTest` (6): request body shape (query/count/freshness-lowercased/language), `X-API-Key` header, country/safesearch injection, web→news result parsing with snippet fallback and domain extraction, 403 → exception, connection-refused → exception — all against a local stub `HttpServer`
  - `YouSearchPluginTest` (5): config → registration, missing key → registered-but-unavailable, default timeout, id-clash → `PluginException`, SPI query → client call passthrough
- Full reactor `mvn package -DskipTests` builds clean with the new module
- No live API call in tests (no credentials needed); live validation once a key is set: ask any agent a question that triggers `web_search` with `you` selected

## Docs

Added a short "You.com provider (optional plugin)" section under WebSearchTool in both `docs/en/tools.md` and `docs/zh/tools.md`, with the install steps and a config table, clearly marked as not part of the default stack.

Happy to adjust the shape if you'd prefer this live outside the main reactor (e.g. as a standalone repo referenced from a community-plugins list), or if the provider id/label should differ.
